### PR TITLE
Use the service ID in the webhook path instead of the service type

### DIFF
--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -31,7 +31,9 @@ func main() {
 	http.Handle("/test", server.MakeJSONAPI(&heartbeatHandler{}))
 	http.Handle("/admin/configureClient", server.MakeJSONAPI(&configureClientHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureService", server.MakeJSONAPI(&configureServiceHandler{db: db, clients: clients}))
-	http.HandleFunc("/services/hooks/", handleWebhook)
+
+	wh := &webhookHandler{db: db}
+	http.HandleFunc("/services/hooks/", wh.handle)
 
 	http.ListenAndServe(bindAddress, nil)
 }


### PR DESCRIPTION
This means we can load the `Service` from the database then invoke
`OnIncomingWebhook` on it, rather than load up a new Service.