### PR TITLE
Send GH webhook notifications based on GH service config

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -18,7 +18,8 @@ func (*heartbeatHandler) OnIncomingRequest(req *http.Request) (interface{}, *err
 }
 
 type webhookHandler struct {
-	db *database.ServiceDB
+	db      *database.ServiceDB
+	clients *clients.Clients
 }
 
 func (wh *webhookHandler) handle(w http.ResponseWriter, req *http.Request) {
@@ -31,7 +32,14 @@ func (wh *webhookHandler) handle(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(404)
 		return
 	}
-	service.OnReceiveWebhook(w, req)
+	cli, err := wh.clients.Client(service.ServiceUserID())
+	if err != nil {
+		log.WithError(err).WithField("user_id", service.ServiceUserID()).Print(
+			"Failed to retrieve matrix client instance")
+		w.WriteHeader(500)
+		return
+	}
+	service.OnReceiveWebhook(w, req, cli)
 }
 
 type configureClientHandler struct {

--- a/src/github.com/matrix-org/go-neb/clients/clients.go
+++ b/src/github.com/matrix-org/go-neb/clients/clients.go
@@ -22,7 +22,7 @@ type Clients struct {
 func New(db *database.ServiceDB) *Clients {
 	clients := &Clients{
 		db:      db,
-		clients: make(map[string]clientEntry),
+		clients: make(map[string]clientEntry), // user_id => clientEntry
 	}
 	return clients
 }

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -32,7 +32,7 @@ func main() {
 	http.Handle("/admin/configureClient", server.MakeJSONAPI(&configureClientHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureService", server.MakeJSONAPI(&configureServiceHandler{db: db, clients: clients}))
 
-	wh := &webhookHandler{db: db}
+	wh := &webhookHandler{db: db, clients: clients}
 	http.HandleFunc("/services/hooks/", wh.handle)
 
 	http.ListenAndServe(bindAddress, nil)

--- a/src/github.com/matrix-org/go-neb/services/echo/echo.go
+++ b/src/github.com/matrix-org/go-neb/services/echo/echo.go
@@ -30,7 +30,7 @@ func (e *echoService) Plugin(roomID string) plugin.Plugin {
 		},
 	}
 }
-func (e *echoService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request) {
+func (e *echoService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
 	w.WriteHeader(200) // Do nothing
 }
 

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -21,13 +21,19 @@ var ownerRepoIssueRegex = regexp.MustCompile("([A-z0-9-_]+)/([A-z0-9-_]+)#([0-9]
 type githubService struct {
 	id     string
 	UserID string
-	Rooms  []string
+	Rooms  map[string][]string // room_id => ["push","issue","pull_request"]
 }
 
 func (s *githubService) ServiceUserID() string { return s.UserID }
 func (s *githubService) ServiceID() string     { return s.id }
 func (s *githubService) ServiceType() string   { return "github" }
-func (s *githubService) RoomIDs() []string     { return s.Rooms }
+func (s *githubService) RoomIDs() []string {
+	var keys []string
+	for k := range s.Rooms {
+		keys = append(keys, k)
+	}
+	return keys
+}
 func (s *githubService) Plugin(roomID string) plugin.Plugin {
 	return plugin.Plugin{
 		Commands: []plugin.Command{},
@@ -62,17 +68,35 @@ func (s *githubService) Plugin(roomID string) plugin.Plugin {
 		},
 	}
 }
-func (s *githubService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request) {
+func (s *githubService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
 	evType, repo, msg, err := webhook.OnReceiveRequest(req, "")
 	if err != nil {
 		w.WriteHeader(err.Code)
 		return
 	}
-	log.WithFields(log.Fields{
-		"type": evType,
-		"msg":  msg,
-		"repo": repo,
-	}).Print("Sending notification")
+
+	for roomID, notif := range s.Rooms {
+		notifyRoom := false
+		for _, notifyType := range notif {
+			if evType == notifyType {
+				notifyRoom = true
+				break
+			}
+		}
+		if notifyRoom {
+			log.WithFields(log.Fields{
+				"type":    evType,
+				"msg":     msg,
+				"repo":    repo,
+				"room_id": roomID,
+			}).Print("Sending notification to room")
+			_, e := cli.SendMessageEvent(roomID, "m.room.message", msg)
+			if e != nil {
+				log.WithError(e).WithField("room_id", roomID).Print(
+					"Failed to send notification to room.")
+			}
+		}
+	}
 	w.WriteHeader(200)
 }
 

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -63,8 +63,17 @@ func (s *githubService) Plugin(roomID string) plugin.Plugin {
 	}
 }
 func (s *githubService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request) {
-	// defer entirely to the webhook package
-	webhook.OnReceiveRequest(w, req, "")
+	evType, repo, msg, err := webhook.OnReceiveRequest(req, "")
+	if err != nil {
+		w.WriteHeader(err.Code)
+		return
+	}
+	log.WithFields(log.Fields{
+		"type": evType,
+		"msg":  msg,
+		"repo": repo,
+	}).Print("Sending notification")
+	w.WriteHeader(200)
 }
 
 // githubClient returns a github Client which can perform Github API operations.

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"github.com/matrix-org/go-neb/matrix"
 	"github.com/matrix-org/go-neb/plugin"
 	"net/http"
 	"net/url"
@@ -32,7 +33,7 @@ type Service interface {
 	ServiceType() string
 	RoomIDs() []string
 	Plugin(roomID string) plugin.Plugin
-	OnReceiveWebhook(w http.ResponseWriter, req *http.Request)
+	OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client)
 }
 
 var servicesByType = map[string]func(string) Service{}


### PR DESCRIPTION
- The github service config now has a map of `room_id => [notification, event, types]`
- When a webhook is received, this map is checked against the event type in the header of the webhook request and is then sent via the service's matrix client.

