### PR TITLE
Add concept of AuthRealms

### DIFF
--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -5,6 +5,7 @@ import (
 	"github.com/matrix-org/go-neb/auth"
 	"github.com/matrix-org/go-neb/clients"
 	"github.com/matrix-org/go-neb/database"
+	_ "github.com/matrix-org/go-neb/realms/github"
 	"github.com/matrix-org/go-neb/server"
 	_ "github.com/matrix-org/go-neb/services/echo"
 	_ "github.com/matrix-org/go-neb/services/github"
@@ -34,7 +35,7 @@ func main() {
 	http.Handle("/test", server.MakeJSONAPI(&heartbeatHandler{}))
 	http.Handle("/admin/configureClient", server.MakeJSONAPI(&configureClientHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureService", server.MakeJSONAPI(&configureServiceHandler{db: db, clients: clients}))
-	http.Handle("/admin/configureAuth", server.MakeJSONAPI(&configureAuthHandler{db: db}))
+	http.Handle("/admin/configureAuthRealm", server.MakeJSONAPI(&configureAuthRealmHandler{db: db}))
 	wh := &webhookHandler{db: db, clients: clients}
 	http.HandleFunc("/services/hooks/", wh.handle)
 

--- a/src/github.com/matrix-org/go-neb/realms/github/github.go
+++ b/src/github.com/matrix-org/go-neb/realms/github/github.go
@@ -1,0 +1,26 @@
+package realms
+
+import (
+	"github.com/matrix-org/go-neb/types"
+)
+
+type githubRealm struct {
+	id              string
+	ClientSecret    string
+	ClientID        string
+	WebhookEndpoint string
+}
+
+func (r *githubRealm) ID() string {
+	return r.id
+}
+
+func (r *githubRealm) Type() string {
+	return "github"
+}
+
+func init() {
+	types.RegisterAuthRealm(func(realmID string) types.AuthRealm {
+		return &githubRealm{id: realmID}
+	})
+}

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -88,3 +88,27 @@ func RegisterAuthModule(am AuthModule) {
 func GetAuthModule(authType string) AuthModule {
 	return authModulesByType[authType]
 }
+
+// AuthRealm represents a place where a user can authenticate themselves.
+// This may static (like github.com) or a specific domain (like matrix.org/jira)
+type AuthRealm interface {
+	ID() string
+	Type() string
+}
+
+var realmsByType = map[string]func(string) AuthRealm{}
+
+// RegisterAuthRealm registers a factory for creating AuthRealm instances.
+func RegisterAuthRealm(factory func(string) AuthRealm) {
+	realmsByType[factory("").Type()] = factory
+}
+
+// CreateAuthRealm creates an AuthRealm of the given type and realm ID.
+// Returns nil if the realm couldn't be created.
+func CreateAuthRealm(realmID, realmType string) AuthRealm {
+	f := realmsByType[realmType]
+	if f == nil {
+		return nil
+	}
+	return f(realmID)
+}


### PR DESCRIPTION
- These represent a place where a user can authenticate themselves.
- They function in the same way as Services (insert/update based on an HTTP API)
- They currently don't *do* a lot other than exist for storing realm-specific
  information (e.g. the `GithubRealm` stores the `ClientSecret` and `ClientID`)

Most of the code is direct copypasta from `Services`. I've replaced the third-party auth endpoint with the realm endpoint for now. Another PR will remove `ThirdPartyAuth` entirely. Another PR after that will add in the concept of `AuthSession` which represents an individual session for an auth realm.