### PR TITLE
Tweak the auth session API to be more transactional

### DIFF
--- a/src/github.com/matrix-org/go-neb/database/db.go
+++ b/src/github.com/matrix-org/go-neb/database/db.go
@@ -13,6 +13,21 @@ type ServiceDB struct {
 	db *sql.DB
 }
 
+// A single global instance of the service DB.
+// XXX: I can't think of any way of doing this without one without creating
+//      cyclical dependencies somewhere -- Kegan
+var globalServiceDB *ServiceDB
+
+// SetServiceDB sets the global service DB instance.
+func SetServiceDB(db *ServiceDB) {
+	globalServiceDB = db
+}
+
+// GetServiceDB gets the global service DB instance.
+func GetServiceDB() *ServiceDB {
+	return globalServiceDB
+}
+
 // Open a SQL database to use as a ServiceDB. This will automatically create
 // the necessary database tables if they aren't already present.
 func Open(databaseType, databaseURL string) (serviceDB *ServiceDB, err error) {

--- a/src/github.com/matrix-org/go-neb/database/schema.go
+++ b/src/github.com/matrix-org/go-neb/database/schema.go
@@ -318,9 +318,12 @@ func selectAuthSessionTxn(txn *sql.Tx, realmID, userID string) (types.AuthSessio
 	if err := json.Unmarshal(realmJSON, realm); err != nil {
 		return nil, err
 	}
-	session := realm.AuthSession(userID, json.RawMessage(sessionJSON))
+	session := realm.AuthSession(userID, realmID)
 	if session == nil {
 		return nil, fmt.Errorf("Cannot create session for given realm")
+	}
+	if err := json.Unmarshal(sessionJSON, session); err != nil {
+		return nil, err
 	}
 	return session, nil
 }

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		log.Panic(err)
 	}
+	database.SetServiceDB(db)
 
 	clients := clients.New(db)
 	if err := clients.Start(); err != nil {
@@ -33,7 +34,7 @@ func main() {
 	http.Handle("/admin/configureClient", server.MakeJSONAPI(&configureClientHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureService", server.MakeJSONAPI(&configureServiceHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureAuthRealm", server.MakeJSONAPI(&configureAuthRealmHandler{db: db}))
-	http.Handle("/admin/configureAuthSession", server.MakeJSONAPI(&configureAuthSessionHandler{db: db}))
+	http.Handle("/admin/requestAuthSession", server.MakeJSONAPI(&requestAuthSessionHandler{db: db}))
 	wh := &webhookHandler{db: db, clients: clients}
 	http.HandleFunc("/services/hooks/", wh.handle)
 

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -59,7 +59,8 @@ func CreateService(serviceID, serviceType string) Service {
 type AuthRealm interface {
 	ID() string
 	Type() string
-	AuthSession(userID string, config json.RawMessage) AuthSession
+	AuthSession(userID, realmID string) AuthSession
+	RequestAuthSession(userID string, config json.RawMessage) interface{}
 }
 
 var realmsByType = map[string]func(string) AuthRealm{}


### PR DESCRIPTION
- Rename the path from /configureAuthSession to /requestAuthSession
- Add a global getter/setter for the `ServiceDB` : this avoids cyclical deps
  because now the Realm wants access to the database, and due to the factory
  pattern it would mean `types.go` would need to import `database`, but
  `database` is already doing so to invoke the factory function in `schema.go`.
- Modify how `AuthSession` is loaded/stored in the database. Now it is just
  a blunt JSON store for Public fields. It is initialised via a new Realm
  interface function `AuthSession(userID, realmID)` which is there to return
  the right `struct` so stuff can be unmarshalled into it.
- Add a new Realm interface function `RequestAuthSession` which is invoked
  when `/requestAuthSession` is hit. It is a direct request/response mapping,
  a JSON blob goes in as a param, and a JSON blob comes out as the return.
  The Realm is free to create/load/update/delete `AuthSessions` inside the
  function. This allows better control over when new sessions are made (or
  whether to return an existing session).