### PR TITLE
Make GithubService construct authenticated github clients

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -198,6 +198,11 @@ func (s *configureServiceHandler) OnIncomingRequest(req *http.Request) (interfac
 		return nil, &errors.HTTPError{err, "Error parsing config JSON", 400}
 	}
 
+	err := service.Register()
+	if err != nil {
+		return nil, &errors.HTTPError{err, "Failed to register service", 500}
+	}
+
 	client, err := s.clients.Client(service.ServiceUserID())
 	if err != nil {
 		return nil, &errors.HTTPError{err, "Unknown matrix client", 400}

--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -200,7 +200,7 @@ func (s *configureServiceHandler) OnIncomingRequest(req *http.Request) (interfac
 
 	err := service.Register()
 	if err != nil {
-		return nil, &errors.HTTPError{err, "Failed to register service", 500}
+		return nil, &errors.HTTPError{err, "Failed to register service: " + err.Error(), 500}
 	}
 
 	client, err := s.clients.Client(service.ServiceUserID())

--- a/src/github.com/matrix-org/go-neb/plugin/plugin.go
+++ b/src/github.com/matrix-org/go-neb/plugin/plugin.go
@@ -31,7 +31,7 @@ type Command struct {
 // the appropriate RFC.
 type Expansion struct {
 	Regexp *regexp.Regexp
-	Expand func(roomID, matchingText string) interface{}
+	Expand func(roomID, userID, matchingText string) interface{}
 }
 
 // matches if the arguments start with the path of the command.
@@ -95,7 +95,7 @@ func runExpansionsForPlugin(plugin Plugin, event *matrix.Event, body string) []i
 				continue
 			}
 			matches[matchingText] = true
-			if response := expansion.Expand(event.RoomID, matchingText); response != nil {
+			if response := expansion.Expand(event.RoomID, event.Sender, matchingText); response != nil {
 				responses = append(responses, response)
 			}
 		}

--- a/src/github.com/matrix-org/go-neb/plugin/plugin_test.go
+++ b/src/github.com/matrix-org/go-neb/plugin/plugin_test.go
@@ -26,21 +26,21 @@ func makeTestEvent(msgtype, body string) *matrix.Event {
 
 type testResponse struct {
 	RoomID    string
-	Sender    string
 	Arguments []string
 }
 
 func makeTestResponse(roomID, sender string, arguments []string) interface{} {
-	return testResponse{roomID, sender, arguments}
+	return testResponse{roomID, arguments}
 }
 
 type testExpansion struct {
 	RoomID       string
+	UserID       string
 	MatchingText string
 }
 
-func makeTestExpansion(roomID, matchingText string) interface{} {
-	return testExpansion{roomID, matchingText}
+func makeTestExpansion(roomID, userID, matchingText string) interface{} {
+	return testExpansion{roomID, userID, matchingText}
 }
 
 func makeTestPlugin(paths [][]string, regexps []*regexp.Regexp) Plugin {
@@ -74,7 +74,7 @@ func TestRunCommands(t *testing.T) {
 		"arg1", "arg 2", "arg 3",
 	})}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("runCommands(%q, %q) == %q, want %q", plugins, event, got, want)
+		t.Errorf("runCommands(\nplugins=%+v\nevent=%+v\n)\n%+v\nwanted: %+v", plugins, event, got, want)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestRunCommandsBestMatch(t *testing.T) {
 		"arg1",
 	})}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("runCommands(%q, %q) == %q, want %q", plugins, event, got, want)
+		t.Errorf("runCommands(\nplugins=%+v\nevent=%+v\n)\n%+v\nwanted: %+v", plugins, event, got, want)
 	}
 }
 
@@ -105,7 +105,7 @@ func TestRunCommandsMultiplePlugins(t *testing.T) {
 		makeTestResponse(myRoomID, mySender, []string{"first", "arg1"}),
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("runCommands(%q, %q) == %q, want %q", plugins, event, got, want)
+		t.Errorf("runCommands(\nplugins=%+v\nevent=%+v\n)\n%+v\nwanted: %+v", plugins, event, got, want)
 	}
 }
 
@@ -119,7 +119,7 @@ func TestRunCommandsInvalidShell(t *testing.T) {
 		makeTestResponse(myRoomID, mySender, []string{"'mismatched", `quotes"`}),
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("runCommands(%q, %q) == %q, want %q", plugins, event, got, want)
+		t.Errorf("runCommands(\nplugins=%+v\nevent=%+v\n)\n%+v\nwanted: %+v", plugins, event, got, want)
 	}
 }
 
@@ -133,12 +133,12 @@ func TestExpansion(t *testing.T) {
 	event := makeTestEvent("m.text", "test banana for scale")
 	got := runCommands(plugins, event)
 	want := []interface{}{
-		makeTestExpansion(myRoomID, "anana"),
-		makeTestExpansion(myRoomID, "ale"),
-		makeTestExpansion(myRoomID, "ban"),
+		makeTestExpansion(myRoomID, mySender, "anana"),
+		makeTestExpansion(myRoomID, mySender, "ale"),
+		makeTestExpansion(myRoomID, mySender, "ban"),
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("runCommands(%q, %q) == %q, want %q", plugins, event, got, want)
+		t.Errorf("runCommands(\nplugins=%+v\nevent=%+v\n)\n%+v\nwanted: %+v", plugins, event, got, want)
 	}
 }
 
@@ -151,9 +151,9 @@ func TestExpansionDuplicateMatches(t *testing.T) {
 	event := makeTestEvent("m.text", "badger badger badger")
 	got := runCommands(plugins, event)
 	want := []interface{}{
-		makeTestExpansion(myRoomID, "badger"),
+		makeTestExpansion(myRoomID, mySender, "badger"),
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("runCommands(%q, %q) == %q, want %q", plugins, event, got, want)
+		t.Errorf("runCommands(\nplugins=%+v\nevent=%+v\n)\n%+v\nwanted: %+v", plugins, event, got, want)
 	}
 }

--- a/src/github.com/matrix-org/go-neb/realms/github/github.go
+++ b/src/github.com/matrix-org/go-neb/realms/github/github.go
@@ -19,23 +19,29 @@ type githubRealm struct {
 	RedirectBaseURI string
 }
 
-type githubSession struct {
+// GithubSession represents an authenticated github session
+type GithubSession struct {
+	// AccessToken is the github access token for the user
 	AccessToken string
-	Scopes      string
-	id          string
-	userID      string
-	realmID     string
+	// Scopes are the set of *ALLOWED* scopes (which may not be the same as the requested scopes)
+	Scopes  string
+	id      string
+	userID  string
+	realmID string
 }
 
-func (s *githubSession) UserID() string {
+// UserID returns the user_id who authorised with Github
+func (s *GithubSession) UserID() string {
 	return s.userID
 }
 
-func (s *githubSession) RealmID() string {
+// RealmID returns the realm ID of the realm which performed the authentication
+func (s *GithubSession) RealmID() string {
 	return s.realmID
 }
 
-func (s *githubSession) ID() string {
+// ID returns the session ID
+func (s *GithubSession) ID() string {
 	return s.id
 }
 
@@ -61,7 +67,7 @@ func (r *githubRealm) RequestAuthSession(userID string, req json.RawMessage) int
 	// TODO: Path is from goneb.go - we should probably factor it out.
 	q.Set("redirect_uri", r.RedirectBaseURI+"/realms/redirects/"+r.ID())
 	u.RawQuery = q.Encode()
-	session := &githubSession{
+	session := &GithubSession{
 		id:      state, // key off the state for redirects
 		userID:  userID,
 		realmID: r.ID(),
@@ -96,7 +102,7 @@ func (r *githubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request
 		failWith(logger, w, 400, "Provided ?state= param is not recognised.", err)
 		return
 	}
-	ghSession, ok := session.(*githubSession)
+	ghSession, ok := session.(*GithubSession)
 	if !ok {
 		failWith(logger, w, 500, "Unexpected session found.", nil)
 		return
@@ -136,7 +142,7 @@ func (r *githubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request
 }
 
 func (r *githubRealm) AuthSession(id, userID, realmID string) types.AuthSession {
-	return &githubSession{
+	return &GithubSession{
 		id:      id,
 		userID:  userID,
 		realmID: realmID,

--- a/src/github.com/matrix-org/go-neb/services/echo/echo.go
+++ b/src/github.com/matrix-org/go-neb/services/echo/echo.go
@@ -18,6 +18,7 @@ func (e *echoService) ServiceUserID() string { return e.UserID }
 func (e *echoService) ServiceID() string     { return e.id }
 func (e *echoService) ServiceType() string   { return "echo" }
 func (e *echoService) RoomIDs() []string     { return e.Rooms }
+func (e *echoService) Register() error       { return nil }
 func (e *echoService) Plugin(roomID string) plugin.Plugin {
 	return plugin.Plugin{
 		Commands: []plugin.Command{

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -35,6 +35,7 @@ type Service interface {
 	RoomIDs() []string
 	Plugin(roomID string) plugin.Plugin
 	OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client)
+	Register() error
 }
 
 var servicesByType = map[string]func(string) Service{}


### PR DESCRIPTION
- Add `Register()` function to Services.
- Include the `userID` in `Expand()` plugin calls.
- Pull out access tokens and use them to construct Github Clients in `GithubService`.