### PR TITLE
Create webhooks in the Github Service

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -213,6 +213,8 @@ func (s *configureServiceHandler) OnIncomingRequest(req *http.Request) (interfac
 		return nil, &errors.HTTPError{err, "Error storing service", 500}
 	}
 
+	service.PostRegister(oldService)
+
 	return &struct {
 		ID        string
 		Type      string

--- a/src/github.com/matrix-org/go-neb/services/echo/echo.go
+++ b/src/github.com/matrix-org/go-neb/services/echo/echo.go
@@ -14,11 +14,12 @@ type echoService struct {
 	Rooms  []string
 }
 
-func (e *echoService) ServiceUserID() string { return e.UserID }
-func (e *echoService) ServiceID() string     { return e.id }
-func (e *echoService) ServiceType() string   { return "echo" }
-func (e *echoService) RoomIDs() []string     { return e.Rooms }
-func (e *echoService) Register() error       { return nil }
+func (e *echoService) ServiceUserID() string          { return e.UserID }
+func (e *echoService) ServiceID() string              { return e.id }
+func (e *echoService) ServiceType() string            { return "echo" }
+func (e *echoService) RoomIDs() []string              { return e.Rooms }
+func (e *echoService) Register() error                { return nil }
+func (e *echoService) PostRegister(old types.Service) {}
 func (e *echoService) Plugin(roomID string) plugin.Plugin {
 	return plugin.Plugin{
 		Commands: []plugin.Command{

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -201,6 +201,12 @@ func (s *githubService) PostRegister(oldService types.Service) {
 		return
 	}
 
+	// TODO: We should be adding webhooks in Register() then removing old hooks in PostRegister()
+	//
+	// By doing both operations in PostRegister(), if some of the requests fail we can end up in
+	// an inconsistent state. It is a lot simpler and easy to reason about this way though, so
+	// for now it will do.
+
 	// remove any existing webhooks this service created on the user's behalf
 	modifyWebhooks(old, cli, true)
 

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -239,7 +239,6 @@ func modifyWebhooks(s *githubService, cli *github.Client, removeHooks bool) {
 		})
 		if removeHooks {
 			removeHook(logger, cli, owner, repo, webhookEndpointURL)
-
 		} else {
 			// make a hook for all GH events since we'll filter it when we receive webhook requests
 			name := "web" // https://developer.github.com/v3/repos/hooks/#create-a-hook
@@ -366,7 +365,6 @@ func removeHook(logger *log.Entry, cli *github.Client, owner, repo, webhookEndpo
 	_, err = cli.Repositories.DeleteHook(owner, repo, *hook.ID)
 	if err != nil {
 		logger.WithError(err).Print("Failed to delete hook")
-		// continue as others may succeed
 	}
 }
 

--- a/src/github.com/matrix-org/go-neb/services/github/webhook/webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/github/webhook/webhook.go
@@ -54,6 +54,9 @@ func OnReceiveRequest(r *http.Request, secretToken string) (string, *github.Repo
 	}).Print("Received Github event")
 
 	if eventType == "ping" {
+		// Github will send a "ping" event when the webhook is first created. We need
+		// to return a 200 in order for the webhook to be marked as "up" (this doesn't
+		// affect delivery, just the tick/cross status flag).
 		return "", nil, nil, &errors.HTTPError{nil, "pong", 200}
 	}
 

--- a/src/github.com/matrix-org/go-neb/services/github/webhook/webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/github/webhook/webhook.go
@@ -53,6 +53,10 @@ func OnReceiveRequest(r *http.Request, secretToken string) (string, *github.Repo
 		"signature":  signatureSHA1,
 	}).Print("Received Github event")
 
+	if eventType == "ping" {
+		return "", nil, nil, &errors.HTTPError{nil, "pong", 200}
+	}
+
 	htmlStr, repo, err := parseGithubEvent(eventType, content)
 	if err != nil {
 		log.WithError(err).Print("Failed to parse github event")

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -36,6 +36,7 @@ type Service interface {
 	Plugin(roomID string) plugin.Plugin
 	OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client)
 	Register() error
+	PostRegister(oldService Service)
 }
 
 var servicesByType = map[string]func(string) Service{}


### PR DESCRIPTION
- Added a new `Service` lifecycle hook: `PostRegister(oldService)`. This exists so the Github service can remove old webhooks.
- Changed config format of Github service to support webhooks.
- Listen for `ping` events from Github when webhooks are made, and reply with a pong (all that matters is a 200 status code).

The next PR will do some tidying up, notably:
 - Expose a way for services to get at their webhook URL without every service having to manually store/parse it.
 - Error-wrap SQL errors in `db.go` so you can see which statement failed (rather than unhelpful "unique key violation" errors which don't tell you what it was trying to do).