### PR TITLE
Add endpoint for GETing AuthSession information for a user/realm tuple

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -269,7 +269,7 @@ type getSessionHandler struct {
 }
 
 func (h *getSessionHandler) OnIncomingRequest(req *http.Request) (interface{}, *errors.HTTPError) {
-	if req.Method != "GET" {
+	if req.Method != "POST" {
 		return nil, &errors.HTTPError{nil, "Unsupported Method", 405}
 	}
 	var body struct {

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -41,6 +41,7 @@ func main() {
 
 	http.Handle("/test", server.MakeJSONAPI(&heartbeatHandler{}))
 	http.Handle("/admin/getService", server.MakeJSONAPI(&getServiceHandler{db: db}))
+	http.Handle("/admin/getSession", server.MakeJSONAPI(&getSessionHandler{db: db}))
 	http.Handle("/admin/configureClient", server.MakeJSONAPI(&configureClientHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureService", server.MakeJSONAPI(&configureServiceHandler{db: db, clients: clients}))
 	http.Handle("/admin/configureAuthRealm", server.MakeJSONAPI(&configureAuthRealmHandler{db: db}))

--- a/src/github.com/matrix-org/go-neb/realms/github/github.go
+++ b/src/github.com/matrix-org/go-neb/realms/github/github.go
@@ -30,6 +30,11 @@ type GithubSession struct {
 	realmID string
 }
 
+// Authenticated returns true if the user has completed the auth process
+func (s *GithubSession) Authenticated() bool {
+	return s.AccessToken != ""
+}
+
 // UserID returns the user_id who authorised with Github
 func (s *GithubSession) UserID() string {
 	return s.userID

--- a/src/github.com/matrix-org/go-neb/realms/jira/jira.go
+++ b/src/github.com/matrix-org/go-neb/realms/jira/jira.go
@@ -46,6 +46,11 @@ type JIRASession struct {
 	AccessSecret  string
 }
 
+// Authenticated returns true if the user has completed the auth process
+func (s *JIRASession) Authenticated() bool {
+	return s.AccessToken != "" && s.AccessSecret != ""
+}
+
 // UserID returns the ID of the user performing the authentication.
 func (s *JIRASession) UserID() string {
 	return s.userID

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -123,4 +123,5 @@ type AuthSession interface {
 	ID() string
 	UserID() string
 	RealmID() string
+	Authenticated() bool
 }


### PR DESCRIPTION
See https://github.com/matrix-org/go-neb/pull/25 first as this PR is based off that one.

Add a new `AuthSession` function `Authenticated()` which returns `true` if the
user has completed the auth process. This allows the caller to distinguish
between:
 - Never done any auth (404s)
 - In the process of doing auth (`Authenticated == false`)
 - Finished doing auth (`Authenticated == true`)

This does **not** yet list *possible* repos for the session.