### PR TITLE
Add StarterLink as a field to the Github Service config

### DIFF
--- a/src/github.com/matrix-org/go-neb/matrix/types.go
+++ b/src/github.com/matrix-org/go-neb/matrix/types.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"encoding/json"
 	"html"
 	"regexp"
 )
@@ -113,4 +114,30 @@ func GetHTMLMessage(msgtype, htmlText string) HTMLMessage {
 		Format:        "org.matrix.custom.html",
 		FormattedBody: htmlText,
 	}
+}
+
+// StarterLinkMessage represents a message with a starter_link custom data.
+type StarterLinkMessage struct {
+	Body string
+	Link string
+}
+
+// MarshalJSON converts this message into actual event content JSON.
+func (m StarterLinkMessage) MarshalJSON() ([]byte, error) {
+	var data map[string]string
+
+	if m.Link != "" {
+		data = map[string]string{
+			"org.matrix.neb.starter_link": m.Link,
+		}
+	}
+
+	msg := struct {
+		MsgType string            `json:"msgtype"`
+		Body    string            `json:"body"`
+		Data    map[string]string `json:"data,omitempty"`
+	}{
+		"m.notice", m.Body, data,
+	}
+	return json.Marshal(msg)
 }

--- a/src/github.com/matrix-org/go-neb/realms/github/github.go
+++ b/src/github.com/matrix-org/go-neb/realms/github/github.go
@@ -12,11 +12,12 @@ import (
 	"net/url"
 )
 
-type githubRealm struct {
+type GithubRealm struct {
 	id           string
 	redirectURL  string
 	ClientSecret string
 	ClientID     string
+	StarterLink  string
 }
 
 // GithubSession represents an authenticated github session
@@ -45,23 +46,23 @@ func (s *GithubSession) ID() string {
 	return s.id
 }
 
-func (r *githubRealm) ID() string {
+func (r *GithubRealm) ID() string {
 	return r.id
 }
 
-func (r *githubRealm) Type() string {
+func (r *GithubRealm) Type() string {
 	return "github"
 }
 
-func (r *githubRealm) Init() error {
+func (r *GithubRealm) Init() error {
 	return nil
 }
 
-func (r *githubRealm) Register() error {
+func (r *GithubRealm) Register() error {
 	return nil
 }
 
-func (r *githubRealm) RequestAuthSession(userID string, req json.RawMessage) interface{} {
+func (r *GithubRealm) RequestAuthSession(userID string, req json.RawMessage) interface{} {
 	state, err := randomString(10)
 	if err != nil {
 		log.WithError(err).Print("Failed to generate state param")
@@ -90,7 +91,7 @@ func (r *githubRealm) RequestAuthSession(userID string, req json.RawMessage) int
 	}{u.String()}
 }
 
-func (r *githubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request) {
+func (r *GithubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request) {
 	// parse out params from the request
 	code := req.URL.Query().Get("code")
 	state := req.URL.Query().Get("state")
@@ -148,7 +149,7 @@ func (r *githubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request
 	w.Write([]byte("OK!"))
 }
 
-func (r *githubRealm) AuthSession(id, userID, realmID string) types.AuthSession {
+func (r *GithubRealm) AuthSession(id, userID, realmID string) types.AuthSession {
 	return &GithubSession{
 		id:      id,
 		userID:  userID,
@@ -175,6 +176,6 @@ func randomString(length int) (string, error) {
 
 func init() {
 	types.RegisterAuthRealm(func(realmID, redirectURL string) types.AuthRealm {
-		return &githubRealm{id: realmID, redirectURL: redirectURL}
+		return &GithubRealm{id: realmID, redirectURL: redirectURL}
 	})
 }

--- a/src/github.com/matrix-org/go-neb/realms/github/github.go
+++ b/src/github.com/matrix-org/go-neb/realms/github/github.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 )
 
+// GithubRealm can handle OAuth processes with github.com
 type GithubRealm struct {
 	id           string
 	redirectURL  string
@@ -46,22 +47,27 @@ func (s *GithubSession) ID() string {
 	return s.id
 }
 
+// ID returns the realm ID
 func (r *GithubRealm) ID() string {
 	return r.id
 }
 
+// Type is github
 func (r *GithubRealm) Type() string {
 	return "github"
 }
 
+// Init does nothing.
 func (r *GithubRealm) Init() error {
 	return nil
 }
 
+// Register does nothing.
 func (r *GithubRealm) Register() error {
 	return nil
 }
 
+// RequestAuthSession generates an OAuth2 URL for this user to auth with github via.
 func (r *GithubRealm) RequestAuthSession(userID string, req json.RawMessage) interface{} {
 	state, err := randomString(10)
 	if err != nil {
@@ -91,6 +97,7 @@ func (r *GithubRealm) RequestAuthSession(userID string, req json.RawMessage) int
 	}{u.String()}
 }
 
+// OnReceiveRedirect processes OAuth redirect requests from Github
 func (r *GithubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request) {
 	// parse out params from the request
 	code := req.URL.Query().Get("code")
@@ -149,6 +156,7 @@ func (r *GithubRealm) OnReceiveRedirect(w http.ResponseWriter, req *http.Request
 	w.Write([]byte("OK!"))
 }
 
+// AuthSession returns a GithubSession for this user
 func (r *GithubRealm) AuthSession(id, userID, realmID string) types.AuthSession {
 	return &GithubSession{
 		id:      id,

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -28,6 +28,7 @@ type githubService struct {
 	ClientUserID       string
 	RealmID            string
 	SecretToken        string
+	StarterLink        string
 	Rooms              map[string]struct { // room_id => {}
 		Repos map[string]struct { // owner/repo => { events: ["push","issue","pull_request"] }
 			Events []string
@@ -49,9 +50,10 @@ func (s *githubService) RoomIDs() []string {
 func (s *githubService) cmdGithubCreate(roomID, userID string, args []string) (interface{}, error) {
 	cli := s.githubClientFor(userID, false)
 	if cli == nil {
-		// TODO: send starter link
-		return &matrix.TextMessage{"m.notice",
-			userID + " : You have not linked your Github account."}, nil
+		return matrix.StarterLinkMessage{
+			Body: "You need to OAuth with Github before you can create issues.",
+			Link: s.StarterLink,
+		}, nil
 	}
 
 	if len(args) < 2 {


### PR DESCRIPTION
Use it verbatim in the responses to !commands when the caller has not authed
with Github.

~~It feels a little wrong that this is a property of the service rather than the realm but \*shrug\*~~ Going to do this by realm because that's what naturally falls out with JIRA and I want starter links to consistently be stored in the same entity type.