### PR TITLE
Change how Services are notified for incoming !commands and expansions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,16 @@ configured. To start an echo service:
     curl -X POST localhost:4050/admin/configureService --data-binary '{
         "Type": "echo",
         "Id": "myserviceid",
+        "UserID": "@goneb:localhost:8448",
         "Config": {
-            "UserID": "@goneb:localhost:8448",
-            "Rooms": ["!QkdpvTwGlrptdeViJx:localhost:8448"]
         }
     }'
     {
         "Type": "echo",
         "Id": "myserviceid",
+        "UserID": "@goneb:localhost:8448",
         "OldConfig": {},
-        "NewConfig": {
-            "UserID": "@goneb:localhost:8448",
-            "Rooms": ["!QkdpvTwGlrptdeViJx:localhost:8448"]
-        }
+        "NewConfig": {}
     }
     
 To retrieve an existing Service:
@@ -74,10 +71,8 @@ To retrieve an existing Service:
     {
         "Type": "echo",
         "Id": "myserviceid",
-        "Config": {
-            "UserID": "@goneb:localhost:8448",
-            "Rooms": ["!QkdpvTwGlrptdeViJx:localhost:8448"]
-        }
+        "UserID": "@goneb:localhost:8448",
+        "Config": {}
     }
 
 Go-neb has a heartbeat listener that returns 200 OK so that load balancers can
@@ -179,10 +174,12 @@ Follow this link and grant access for NEB to act on your behalf.
 curl -X POST localhost:4050/admin/configureService --data-binary '{
     "Type": "github",
     "Id": "mygithubserviceid",
+    "UserID": "@goneb:localhost",
     "Config": {
     	"RealmID": "mygithubrealm",
-        "BotUserID": "@goneb:localhost",
         "ClientUserID": "@example:localhost",
+        "HandleCommands": true,
+        "HandleExpansions": true,
         "Rooms": {
         	"!EmwxeXCVubhskuWvaw:localhost": {
         		"Repos": {
@@ -285,8 +282,8 @@ Follow this link and grant access for NEB to act on your behalf.
 curl -X POST localhost:4050/admin/configureService --data-binary '{
     "Type": "jira",
     "Id": "jid",
+    "UserID": "@goneb:localhost",
     "Config": {
-        "BotUserID": "@goneb:localhost",
         "ClientUserID": "@example:localhost",
         "Rooms": {
             "!EmwxeXCVubhskuWvaw:localhost": {

--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -214,17 +214,20 @@ func (s *configureServiceHandler) OnIncomingRequest(req *http.Request) (interfac
 	var body struct {
 		ID     string
 		Type   string
+		UserID string
 		Config json.RawMessage
 	}
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		return nil, &errors.HTTPError{err, "Error parsing request JSON", 400}
 	}
 
-	if body.ID == "" || body.Type == "" || body.Config == nil {
-		return nil, &errors.HTTPError{nil, `Must supply a "ID", a "Type" and a "Config"`, 400}
+	if body.ID == "" || body.Type == "" || body.UserID == "" || body.Config == nil {
+		return nil, &errors.HTTPError{
+			nil, `Must supply an "ID", a "Type", a "UserID" and a "Config"`, 400,
+		}
 	}
 
-	service, err := types.CreateService(body.ID, body.Type, body.Config)
+	service, err := types.CreateService(body.ID, body.Type, body.UserID, body.Config)
 	if err != nil {
 		return nil, &errors.HTTPError{err, "Error parsing config JSON", 400}
 	}

--- a/src/github.com/matrix-org/go-neb/database/schema.go
+++ b/src/github.com/matrix-org/go-neb/database/schema.go
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS services (
 	time_updated_ms BIGINT NOT NULL,
 	UNIQUE(service_id)
 );
+CREATE UNIQUE INDEX IF NOT EXISTS service_id_and_user_idx ON services(service_user_id, service_id);
 
 CREATE TABLE IF NOT EXISTS matrix_clients (
 	user_id TEXT NOT NULL,

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -51,9 +51,6 @@ func main() {
 	database.SetServiceDB(db)
 
 	clients := clients.New(db)
-	if err := clients.Start(); err != nil {
-		log.Panic(err)
-	}
 
 	http.Handle("/test", server.MakeJSONAPI(&heartbeatHandler{}))
 	http.Handle("/admin/getService", server.MakeJSONAPI(&getServiceHandler{db: db}))

--- a/src/github.com/matrix-org/go-neb/services/echo/echo.go
+++ b/src/github.com/matrix-org/go-neb/services/echo/echo.go
@@ -9,15 +9,13 @@ import (
 )
 
 type echoService struct {
-	id     string
-	UserID string
-	Rooms  []string
+	id            string
+	serviceUserID string
 }
 
-func (e *echoService) ServiceUserID() string          { return e.UserID }
+func (e *echoService) ServiceUserID() string          { return e.serviceUserID }
 func (e *echoService) ServiceID() string              { return e.id }
 func (e *echoService) ServiceType() string            { return "echo" }
-func (e *echoService) RoomIDs() []string              { return e.Rooms }
 func (e *echoService) Register() error                { return nil }
 func (e *echoService) PostRegister(old types.Service) {}
 func (e *echoService) Plugin(roomID string) plugin.Plugin {
@@ -37,7 +35,7 @@ func (e *echoService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request,
 }
 
 func init() {
-	types.RegisterService(func(serviceID, webhookEndpointURL string) types.Service {
-		return &echoService{id: serviceID}
+	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {
+		return &echoService{id: serviceID, serviceUserID: serviceUserID}
 	})
 }

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -29,6 +29,8 @@ type githubService struct {
 	ClientUserID       string
 	RealmID            string
 	SecretToken        string
+	HandleCommands     bool
+	HandleExpansions   bool
 	Rooms              map[string]struct { // room_id => {}
 		Repos map[string]struct { // owner/repo => { events: ["push","issue","pull_request"] }
 			Events []string
@@ -48,6 +50,9 @@ func (s *githubService) RoomIDs() []string {
 }
 
 func (s *githubService) cmdGithubCreate(roomID, userID string, args []string) (interface{}, error) {
+	if !s.HandleCommands {
+		return nil, nil
+	}
 	cli := s.githubClientFor(userID, false)
 	if cli == nil {
 		r, err := database.GetServiceDB().LoadAuthRealm(s.RealmID)
@@ -104,6 +109,9 @@ func (s *githubService) cmdGithubCreate(roomID, userID string, args []string) (i
 }
 
 func (s *githubService) expandIssue(roomID, userID string, matchingGroups []string) interface{} {
+	if !s.HandleExpansions {
+		return nil
+	}
 	// matchingGroups => ["foo/bar#11", "foo", "bar", "11"]
 	if len(matchingGroups) != 4 {
 		log.WithField("groups", matchingGroups).Print("Unexpected number of groups")

--- a/src/github.com/matrix-org/go-neb/services/jira/jira.go
+++ b/src/github.com/matrix-org/go-neb/services/jira/jira.go
@@ -25,8 +25,8 @@ var projectKeyRegex = regexp.MustCompile("^[A-z]+$")
 
 type jiraService struct {
 	id                 string
+	serviceUserID      string
 	webhookEndpointURL string
-	BotUserID          string
 	ClientUserID       string
 	Rooms              map[string]struct { // room_id => {}
 		Realms map[string]struct { // realm_id => {}  Determines the JIRA endpoint
@@ -38,16 +38,9 @@ type jiraService struct {
 	}
 }
 
-func (s *jiraService) ServiceUserID() string { return s.BotUserID }
+func (s *jiraService) ServiceUserID() string { return s.serviceUserID }
 func (s *jiraService) ServiceID() string     { return s.id }
 func (s *jiraService) ServiceType() string   { return "jira" }
-func (s *jiraService) RoomIDs() []string {
-	var keys []string
-	for k := range s.Rooms {
-		keys = append(keys, k)
-	}
-	return keys
-}
 func (s *jiraService) Register() error {
 	// We only ever make 1 JIRA webhook which listens for all projects and then filter
 	// on receive. So we simply need to know if we need to make a webhook or not. We
@@ -408,7 +401,11 @@ func htmlForEvent(whe *webhook.Event, jiraBaseURL string) string {
 }
 
 func init() {
-	types.RegisterService(func(serviceID, webhookEndpointURL string) types.Service {
-		return &jiraService{id: serviceID, webhookEndpointURL: webhookEndpointURL}
+	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {
+		return &jiraService{
+			id:                 serviceID,
+			serviceUserID:      serviceUserID,
+			webhookEndpointURL: webhookEndpointURL,
+		}
 	})
 }


### PR DESCRIPTION
Previously, we would notify `Services` based on matching the `room_id` of the
event with a list of `RoomIDs()` which the service returned.

Now we notify `Services` based on matching the `user_id` of the client listening
for events. This means that the service will receive more events because there
isn't a filter on a set of room IDs.

This is required in order to implement "auto-join on invite" semantics for
Services, as the room ID is not known at that point in time.

Also add flags for `HandleCommands` and `HandleExpansions` to control whether the service should handle them when they receive them.