### PR TITLE
Client ID is optional when creating Github services

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -224,7 +224,11 @@ func (s *githubService) PostRegister(oldService types.Service) {
 	// PostRegister handles creating/destroying webhooks, which is only valid if this service
 	// is configured on behalf of a client.
 	if s.ClientUserID == "" {
-		// TODO: We should log an error here if the service has any webhook config in Rooms
+		if len(s.Rooms) != 0 {
+			log.WithFields(log.Fields{
+				"Rooms": s.Rooms,
+			}).Error("Empty ClientUserID but a webhook config was supplied.")
+		}
 		return
 	}
 

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -224,6 +224,7 @@ func (s *githubService) PostRegister(oldService types.Service) {
 	// PostRegister handles creating/destroying webhooks, which is only valid if this service
 	// is configured on behalf of a client.
 	if s.ClientUserID == "" {
+		// TODO: We should log an error here if the service has any webhook config in Rooms
 		return
 	}
 

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -26,7 +26,7 @@ type githubService struct {
 	id                 string
 	serviceUserID      string
 	webhookEndpointURL string
-	ClientUserID       string
+	ClientUserID       string // optional; required for webhooks
 	RealmID            string
 	SecretToken        string
 	HandleCommands     bool
@@ -193,8 +193,8 @@ func (s *githubService) OnReceiveWebhook(w http.ResponseWriter, req *http.Reques
 	w.WriteHeader(200)
 }
 func (s *githubService) Register() error {
-	if s.RealmID == "" || s.ClientUserID == "" {
-		return fmt.Errorf("RealmID and ClientUserID are required")
+	if s.RealmID == "" {
+		return fmt.Errorf("RealmID is required")
 	}
 	// check realm exists
 	realm, err := database.GetServiceDB().LoadAuthRealm(s.RealmID)
@@ -206,11 +206,13 @@ func (s *githubService) Register() error {
 		return fmt.Errorf("Realm is of type '%s', not 'github'", realm.Type())
 	}
 
-	// In order to register the GH service, you must have authed with GH.
-	cli := s.githubClientFor(s.ClientUserID, false)
-	if cli == nil {
-		return fmt.Errorf(
-			"User %s does not have a Github auth session with realm %s.", s.ClientUserID, realm.ID())
+	if s.ClientUserID != "" {
+		// In order to register the GH service as a client, you must have authed with GH.
+		cli := s.githubClientFor(s.ClientUserID, false)
+		if cli == nil {
+			return fmt.Errorf(
+				"User %s does not have a Github auth session with realm %s.", s.ClientUserID, realm.ID())
+		}
 	}
 
 	log.Infof("%+v", s)
@@ -219,6 +221,12 @@ func (s *githubService) Register() error {
 }
 
 func (s *githubService) PostRegister(oldService types.Service) {
+	// PostRegister handles creating/destroying webhooks, which is only valid if this service
+	// is configured on behalf of a client.
+	if s.ClientUserID == "" {
+		return
+	}
+
 	cli := s.githubClientFor(s.ClientUserID, false)
 	if cli == nil {
 		log.Errorf("PostRegister: %s does not have a github session", s.ClientUserID)


### PR DESCRIPTION
We only use it for making webhooks (to determine which GH account to load up).
We need it to be optional for the global GH bot to work (which has no account
and uses the account of whoever issued the !command to do the work).