### PR TITLE
Mutex-guard services with the same ID being modified concurrently

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -222,6 +222,9 @@ func (s *configureServiceHandler) getMutexForServiceID(serviceID string) *sync.M
 	defer s.mapMutex.Unlock()
 	m := s.mutexByServiceID[serviceID]
 	if m == nil {
+		// XXX TODO: There's a memory leak here. The amount of mutexes created is unbounded, as there will be 1 per service which are never deleted.
+		// A better solution would be to have a striped hash map with a bounded pool of mutexes. We can't live with a single global mutex because the Register()
+		// function this is protecting does many many HTTP requests which can take a long time on bad networks and will head of line block other services.
 		m = &sync.Mutex{}
 		s.mutexByServiceID[serviceID] = m
 	}

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -59,7 +59,7 @@ func main() {
 	http.Handle("/admin/getService", server.MakeJSONAPI(&getServiceHandler{db: db}))
 	http.Handle("/admin/getSession", server.MakeJSONAPI(&getSessionHandler{db: db}))
 	http.Handle("/admin/configureClient", server.MakeJSONAPI(&configureClientHandler{db: db, clients: clients}))
-	http.Handle("/admin/configureService", server.MakeJSONAPI(&configureServiceHandler{db: db, clients: clients}))
+	http.Handle("/admin/configureService", server.MakeJSONAPI(newConfigureServiceHandler(db, clients)))
 	http.Handle("/admin/configureAuthRealm", server.MakeJSONAPI(&configureAuthRealmHandler{db: db}))
 	http.Handle("/admin/requestAuthSession", server.MakeJSONAPI(&requestAuthSessionHandler{db: db}))
 	wh := &webhookHandler{db: db, clients: clients}


### PR DESCRIPTION
Also treat 422 "already exists" errors as success.