### PR TITLE
Support bot options and implement github bot options for default repos

### DIFF
--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -31,6 +31,14 @@ func (c *ClientConfig) Check() error {
 	return nil
 }
 
+// BotOptions for a given bot user in a given room
+type BotOptions struct {
+	RoomID      string
+	UserID      string
+	SetByUserID string
+	Options     map[string]interface{}
+}
+
 // A Service is the configuration for a bot service.
 type Service interface {
 	ServiceUserID() string


### PR DESCRIPTION
- Add a new `bot_options` table
- Allow github expansions/commands to omit the owner/repo and use a default if set