### PR TITLE
Set the desired DisplayName for a client when it is being configured

### DIFF
--- a/src/github.com/matrix-org/go-neb/clients/clients.go
+++ b/src/github.com/matrix-org/go-neb/clients/clients.go
@@ -115,6 +115,18 @@ func (c *Clients) updateClientInDB(newConfig types.ClientConfig) (new clientEntr
 		return
 	}
 
+	// set the new display name if they differ
+	if old.config.DisplayName != new.config.DisplayName {
+		if err := new.client.SetDisplayName(new.config.DisplayName); err != nil {
+			// whine about it but don't stop: this isn't fatal.
+			log.WithFields(log.Fields{
+				log.ErrorKey:  err,
+				"displayname": new.config.DisplayName,
+				"user_id":     new.config.UserID,
+			}).Error("Failed to set display name")
+		}
+	}
+
 	if old.config, err = c.db.StoreMatrixClientConfig(new.config); err != nil {
 		new.client.StopSync()
 		return

--- a/src/github.com/matrix-org/go-neb/clients/clients.go
+++ b/src/github.com/matrix-org/go-neb/clients/clients.go
@@ -219,7 +219,9 @@ func (c *Clients) newClient(config types.ClientConfig) (*matrix.Client, error) {
 		})
 	}
 
-	go client.Sync()
+	if config.Sync {
+		go client.Sync()
+	}
 
 	return client, nil
 }

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -18,6 +18,7 @@ type ClientConfig struct {
 	AccessToken   string // The matrix access token to authenticate the requests with.
 	Sync          bool   // True to start a sync stream for this user
 	AutoJoinRooms bool   // True to automatically join all rooms for this user
+	DisplayName   string // The display name to set for the matrix client
 }
 
 // Check that the client has the correct fields.


### PR DESCRIPTION
Also, only start a sync stream if we have been instructed to do so (`github-webhook` services typically don't, whereas `github` service does).