### PR TITLE
Allow github webhooks to be explicitly removed

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -270,6 +270,8 @@ func (s *configureServiceHandler) OnIncomingRequest(req *http.Request) (interfac
 		return nil, &errors.HTTPError{err, "Error storing service", 500}
 	}
 
+	service.PostRegister(old)
+
 	return &struct {
 		ID        string
 		Type      string

--- a/src/github.com/matrix-org/go-neb/services/echo/echo.go
+++ b/src/github.com/matrix-org/go-neb/services/echo/echo.go
@@ -17,6 +17,7 @@ func (e *echoService) ServiceUserID() string                                    
 func (e *echoService) ServiceID() string                                              { return e.id }
 func (e *echoService) ServiceType() string                                            { return "echo" }
 func (e *echoService) Register(oldService types.Service, client *matrix.Client) error { return nil }
+func (e *echoService) PostRegister(oldService types.Service)                          {}
 func (e *echoService) Plugin(cli *matrix.Client, roomID string) plugin.Plugin {
 	return plugin.Plugin{
 		Commands: []plugin.Command{

--- a/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
+++ b/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
@@ -42,6 +42,7 @@ func (s *giphyService) ServiceType() string   { return "giphy" }
 func (s *giphyService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
 }
 func (s *giphyService) Register(oldService types.Service, client *matrix.Client) error { return nil }
+func (s *giphyService) PostRegister(oldService types.Service)                          {}
 
 func (s *giphyService) Plugin(client *matrix.Client, roomID string) plugin.Plugin {
 	return plugin.Plugin{

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -204,6 +204,8 @@ func (s *githubService) Register(oldService types.Service, client *matrix.Client
 	return nil
 }
 
+func (s *githubService) PostRegister(oldService types.Service) {}
+
 // defaultRepo returns the default repo for the given room, or an empty string.
 func (s *githubService) defaultRepo(roomID string) string {
 	logger := log.WithFields(log.Fields{

--- a/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
@@ -189,7 +189,7 @@ func (s *githubWebhookService) PostRegister(oldService types.Service) {
 			log.WithFields(log.Fields{
 				log.ErrorKey: err,
 				"repo":       r,
-			}).Error("Failed to remove webhook")
+			}).Warn("Failed to remove webhook")
 		}
 	}
 }

--- a/src/github.com/matrix-org/go-neb/services/jira/jira.go
+++ b/src/github.com/matrix-org/go-neb/services/jira/jira.go
@@ -38,9 +38,10 @@ type jiraService struct {
 	}
 }
 
-func (s *jiraService) ServiceUserID() string { return s.serviceUserID }
-func (s *jiraService) ServiceID() string     { return s.id }
-func (s *jiraService) ServiceType() string   { return "jira" }
+func (s *jiraService) ServiceUserID() string                 { return s.serviceUserID }
+func (s *jiraService) ServiceID() string                     { return s.id }
+func (s *jiraService) ServiceType() string                   { return "jira" }
+func (s *jiraService) PostRegister(oldService types.Service) {}
 func (s *jiraService) Register(oldService types.Service, client *matrix.Client) error {
 	// We only ever make 1 JIRA webhook which listens for all projects and then filter
 	// on receive. So we simply need to know if we need to make a webhook or not. We

--- a/src/github.com/matrix-org/go-neb/types/types.go
+++ b/src/github.com/matrix-org/go-neb/types/types.go
@@ -47,7 +47,16 @@ type Service interface {
 	ServiceType() string
 	Plugin(cli *matrix.Client, roomID string) plugin.Plugin
 	OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client)
+	// A lifecycle function which is invoked when the service is being registered. The old service, if one exists, is provided,
+	// along with a Client instance for ServiceUserID(). If this function returns an error, the service will not be registered
+	// or persisted to the database, and the user's request will fail. This can be useful if you depend on external factors
+	// such as registering webhooks.
 	Register(oldService Service, client *matrix.Client) error
+	// A lifecycle function which is invoked after the service has been successfully registered and persisted to the database.
+	// This function is invoked within the critical section for configuring services, guaranteeing that there will not be
+	// concurrent modifications to this service whilst this function executes. This lifecycle hook should be used to clean
+	// up resources which are no longer needed (e.g. removing old webhooks).
+	PostRegister(oldService Service)
 }
 
 var baseURL = ""


### PR DESCRIPTION
Removing a repo entirely from a service will now remove the webhook in the
`PostRegister()` function. This function is still within the `configureService`
critical section to prevent another request for the same service racing with
the cleanup process.