### PR TITLE
Persist next_batch tokens

### DIFF
--- a/src/github.com/matrix-org/go-neb/clients/clients.go
+++ b/src/github.com/matrix-org/go-neb/clients/clients.go
@@ -238,7 +238,7 @@ func (c *Clients) newClient(config types.ClientConfig) (*matrix.Client, error) {
 	}
 
 	client := matrix.NewClient(homeserverURL, config.AccessToken, config.UserID)
-	client.NextBatch = nextBatchStore{c.db}
+	client.NextBatchStorer = nextBatchStore{c.db}
 
 	// TODO: Check that the access token is valid for the userID by peforming
 	// a request against the server.

--- a/src/github.com/matrix-org/go-neb/database/db.go
+++ b/src/github.com/matrix-org/go-neb/database/db.go
@@ -77,6 +77,14 @@ func (d *ServiceDB) LoadMatrixClientConfig(userID string) (config types.ClientCo
 	return
 }
 
+// UpdateNextBatch updates the next_batch token for the given user.
+func (d *ServiceDB) UpdateNextBatch(userID, nextBatch string) (err error) {
+	err = runTransaction(d.db, func(txn *sql.Tx) error {
+		return updateNextBatchTxn(txn, userID, nextBatch)
+	})
+	return
+}
+
 // LoadService loads a service from the database.
 // Returns sql.ErrNoRows if the service isn't in the database.
 func (d *ServiceDB) LoadService(serviceID string) (service types.Service, err error) {

--- a/src/github.com/matrix-org/go-neb/database/db.go
+++ b/src/github.com/matrix-org/go-neb/database/db.go
@@ -85,6 +85,15 @@ func (d *ServiceDB) UpdateNextBatch(userID, nextBatch string) (err error) {
 	return
 }
 
+// LoadNextBatch loads the next_batch token for the given user.
+func (d *ServiceDB) LoadNextBatch(userID string) (nextBatch string, err error) {
+	err = runTransaction(d.db, func(txn *sql.Tx) error {
+		nextBatch, err = selectNextBatchTxn(txn, userID)
+		return err
+	})
+	return
+}
+
 // LoadService loads a service from the database.
 // Returns sql.ErrNoRows if the service isn't in the database.
 func (d *ServiceDB) LoadService(serviceID string) (service types.Service, err error) {

--- a/src/github.com/matrix-org/go-neb/database/schema.go
+++ b/src/github.com/matrix-org/go-neb/database/schema.go
@@ -129,6 +129,15 @@ func updateMatrixClientConfigTxn(txn *sql.Tx, now time.Time, config types.Client
 	return err
 }
 
+const updateNextBatchSQL = `
+UPDATE matrix_clients SET next_batch = $1 WHERE user_id = $2
+`
+
+func updateNextBatchTxn(txn *sql.Tx, userID, nextBatch string) error {
+	_, err := txn.Exec(updateNextBatchSQL, nextBatch, userID)
+	return err
+}
+
 const selectServiceSQL = `
 SELECT service_type, service_user_id, service_json FROM services
 	WHERE service_id = $1

--- a/src/github.com/matrix-org/go-neb/database/schema.go
+++ b/src/github.com/matrix-org/go-neb/database/schema.go
@@ -138,6 +138,19 @@ func updateNextBatchTxn(txn *sql.Tx, userID, nextBatch string) error {
 	return err
 }
 
+const selectNextBatchSQL = `
+SELECT next_batch FROM matrix_clients WHERE user_id = $1
+`
+
+func selectNextBatchTxn(txn *sql.Tx, userID string) (string, error) {
+	var nextBatch string
+	row := txn.QueryRow(selectNextBatchSQL, userID)
+	if err := row.Scan(&nextBatch); err != nil {
+		return "", err
+	}
+	return nextBatch, nil
+}
+
 const selectServiceSQL = `
 SELECT service_type, service_user_id, service_json FROM services
 	WHERE service_id = $1

--- a/src/github.com/matrix-org/go-neb/matrix/matrix.go
+++ b/src/github.com/matrix-org/go-neb/matrix/matrix.go
@@ -206,7 +206,7 @@ func (cli *Client) Sync() {
 		"user_id": cli.UserID,
 	})
 
-	// TODO: Store the filter ID and sync token in the database
+	// TODO: Store the filter ID in the database
 	filterID, err := cli.createFilter()
 	if err != nil {
 		logger.WithError(err).Fatal("Failed to create filter")
@@ -247,8 +247,6 @@ func (cli *Client) Sync() {
 		//  Check that the syncing state hasn't changed
 		// Either because we've stopped syncing or another sync has been started.
 		// We discard the response from our sync.
-		// TODO: Store the next_batch token so that the next sync can resume
-		// from where this sync left off.
 		if cli.getSyncingID() != syncingID {
 			logger.Print("Stopping sync")
 			return


### PR DESCRIPTION
- Indirect this through a `NextBatchStorer` interface type to get around circular dependencies
which are formed if you try to inline it in the `Sync()` while loop.

- Fork out event handlers to separate functions in `Clients` to make gocyclo happy.

- Add `SELECT` and `UPDATE` queries for `next_batch`.

- Set the filter limit to `50` to actually get >1 timeline event.

- Check if the `next_batch` was originally the empty string and if so, do not pass the results to the `Worker` as this is the first sync evar (subsequent syncs after restarts use an existing token in the database).