### PR TITLE
Add /admin/removeAuthSession

### DIFF
--- a/src/github.com/matrix-org/go-neb/database/db.go
+++ b/src/github.com/matrix-org/go-neb/database/db.go
@@ -197,6 +197,14 @@ func (d *ServiceDB) StoreAuthSession(session types.AuthSession) (old types.AuthS
 	return
 }
 
+// RemoveAuthSession removes the auth session for the given user on the given realm.
+// No error is returned if the session did not exist in the first place.
+func (d *ServiceDB) RemoveAuthSession(realmID, userID string) error {
+	return runTransaction(d.db, func(txn *sql.Tx) error {
+		return deleteAuthSessionTxn(txn, realmID, userID)
+	})
+}
+
 // LoadAuthSessionByUser loads an AuthSession from the database based on the given
 // realm and user ID.
 // Returns sql.ErrNoRows if the session isn't in the database.

--- a/src/github.com/matrix-org/go-neb/database/schema.go
+++ b/src/github.com/matrix-org/go-neb/database/schema.go
@@ -336,6 +336,15 @@ func insertAuthSessionTxn(txn *sql.Tx, now time.Time, session types.AuthSession)
 	return err
 }
 
+const deleteAuthSessionSQL = `
+DELETE FROM auth_sessions WHERE realm_id=$1 AND user_id=$2
+`
+
+func deleteAuthSessionTxn(txn *sql.Tx, realmID, userID string) error {
+	_, err := txn.Exec(deleteAuthSessionSQL, realmID, userID)
+	return err
+}
+
 const selectAuthSessionByUserSQL = `
 SELECT session_id, realm_type, realm_json, session_json FROM auth_sessions
 	JOIN auth_realms ON auth_sessions.realm_id = auth_realms.realm_id

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -63,6 +63,7 @@ func main() {
 	http.Handle("/admin/configureService", server.MakeJSONAPI(newConfigureServiceHandler(db, clients)))
 	http.Handle("/admin/configureAuthRealm", server.MakeJSONAPI(&configureAuthRealmHandler{db: db}))
 	http.Handle("/admin/requestAuthSession", server.MakeJSONAPI(&requestAuthSessionHandler{db: db}))
+	http.Handle("/admin/removeAuthSession", server.MakeJSONAPI(&removeAuthSessionHandler{db: db}))
 	wh := &webhookHandler{db: db, clients: clients}
 	http.HandleFunc("/services/hooks/", wh.handle)
 	rh := &realmRedirectHandler{db: db}


### PR DESCRIPTION
Allows users to nuke their OAuth credentials. Currently this just does a database `DELETE` as neither Github nor JIRA need you to hit any special `/logout` API.