### PR TITLE
Implement polling for Services

### DIFF
--- a/src/github.com/matrix-org/go-neb/database/db.go
+++ b/src/github.com/matrix-org/go-neb/database/db.go
@@ -125,6 +125,19 @@ func (d *ServiceDB) LoadServicesForUser(serviceUserID string) (services []types.
 	return
 }
 
+// LoadServicesByType loads all the bot services configured for a given type.
+// Returns an empty list if there aren't any services configured.
+func (d *ServiceDB) LoadServicesByType(serviceType string) (services []types.Service, err error) {
+	err = runTransaction(d.db, func(txn *sql.Tx) error {
+		services, err = selectServicesByTypeTxn(txn, serviceType)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return
+}
+
 // StoreService stores a service into the database either by inserting a new
 // service or updating an existing service. Returns the old service if there
 // was one.

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -5,6 +5,7 @@ import (
 	"github.com/matrix-org/dugong"
 	"github.com/matrix-org/go-neb/clients"
 	"github.com/matrix-org/go-neb/database"
+	"github.com/matrix-org/go-neb/polling"
 	_ "github.com/matrix-org/go-neb/realms/github"
 	_ "github.com/matrix-org/go-neb/realms/jira"
 	"github.com/matrix-org/go-neb/server"
@@ -12,6 +13,7 @@ import (
 	_ "github.com/matrix-org/go-neb/services/giphy"
 	_ "github.com/matrix-org/go-neb/services/github"
 	_ "github.com/matrix-org/go-neb/services/jira"
+	_ "github.com/matrix-org/go-neb/services/rss"
 	"github.com/matrix-org/go-neb/types"
 	_ "github.com/mattn/go-sqlite3"
 	"net/http"
@@ -68,6 +70,10 @@ func main() {
 	http.HandleFunc("/services/hooks/", wh.handle)
 	rh := &realmRedirectHandler{db: db}
 	http.HandleFunc("/realms/redirects/", rh.handle)
+
+	if err := polling.Start(); err != nil {
+		log.Panic(err)
+	}
 
 	http.ListenAndServe(bindAddress, nil)
 }

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -13,7 +13,6 @@ import (
 	_ "github.com/matrix-org/go-neb/services/giphy"
 	_ "github.com/matrix-org/go-neb/services/github"
 	_ "github.com/matrix-org/go-neb/services/jira"
-	_ "github.com/matrix-org/go-neb/services/rss"
 	"github.com/matrix-org/go-neb/types"
 	_ "github.com/mattn/go-sqlite3"
 	"net/http"

--- a/src/github.com/matrix-org/go-neb/polling/polling.go
+++ b/src/github.com/matrix-org/go-neb/polling/polling.go
@@ -1,0 +1,44 @@
+package polling
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/go-neb/database"
+	"github.com/matrix-org/go-neb/types"
+	"time"
+)
+
+var shouldPoll = make(map[string]bool) // Service ID => yay/nay
+
+// Start polling already existing services
+func Start() error {
+	log.Print("Start polling")
+	// Work out which service types require polling
+	for serviceType, poller := range types.PollersByType() {
+		if poller == nil {
+			continue
+		}
+		// Query for all services with said service type
+		srvs, err := database.GetServiceDB().LoadServicesByType(serviceType)
+		if err != nil {
+			return err
+		}
+		for _, s := range srvs {
+			shouldPoll[s.ServiceID()] = true
+			go StartPolling(s, poller)
+		}
+	}
+	return nil
+}
+
+// StartPolling begins the polling loop for this service. Does not return, so call this
+// as a goroutine!
+func StartPolling(service types.Service, poller types.Poller) {
+	for {
+		if !shouldPoll[service.ServiceID()] {
+			log.WithField("service_id", service.ServiceID()).Info("Terminating poll.")
+			break
+		}
+		poller.OnPoll(service)
+		time.Sleep(time.Duration(poller.IntervalSecs()) * time.Second)
+	}
+}

--- a/src/github.com/matrix-org/go-neb/polling/polling.go
+++ b/src/github.com/matrix-org/go-neb/polling/polling.go
@@ -1,17 +1,24 @@
 package polling
 
 import (
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/types"
+	"sync"
 	"time"
 )
 
-var shouldPoll = make(map[string]bool) // Service ID => yay/nay
+// Remember when we first started polling on this service ID. Polling routines will
+// continually check this time. If the service gets updated, this will change, prompting
+// older instances to die away. If this service gets removed, the time will be 0.
+var (
+	pollMutex     sync.Mutex
+	startPollTime = make(map[string]int64) // ServiceID => unix timestamp
+)
 
 // Start polling already existing services
 func Start() error {
-	log.Print("Start polling")
 	// Work out which service types require polling
 	for serviceType, poller := range types.PollersByType() {
 		if poller == nil {
@@ -23,22 +30,74 @@ func Start() error {
 			return err
 		}
 		for _, s := range srvs {
-			shouldPoll[s.ServiceID()] = true
-			go StartPolling(s, poller)
+			if err := StartPolling(s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-// StartPolling begins the polling loop for this service. Does not return, so call this
+// StartPolling begins a polling loop for this service.
+// If one already exists for this service, it will be instructed to die. The new poll will not wait for this to happen,
+// so there may be a brief period of overlap. It is safe to immediately call `StopPolling(service)` to immediately terminate
+// this poll.
+func StartPolling(service types.Service) error {
+	p := types.PollersByType()[service.ServiceType()]
+	if p == nil {
+		return fmt.Errorf("Service %s (type=%s) doesn't have a Poller", service.ServiceID(), service.ServiceType())
+	}
+	// Set the poll time BEFORE spinning off the goroutine in case the caller immediately stops us. If we don't do this here,
+	// we risk them setting the ts to 0 BEFORE we've set the start time, resulting in a poll when one was not intended.
+	ts := time.Now().UnixNano()
+	setPollStartTime(service, ts)
+	go pollLoop(service, p, ts)
+	return nil
+}
+
+// StopPolling stops all pollers for this service.
+func StopPolling(service types.Service) {
+	log.WithFields(log.Fields{
+		"service_id":   service.ServiceID(),
+		"service_type": service.ServiceType(),
+	}).Info("StopPolling")
+	setPollStartTime(service, 0)
+}
+
+// pollLoop begins the polling loop for this service. Does not return, so call this
 // as a goroutine!
-func StartPolling(service types.Service, poller types.Poller) {
+func pollLoop(service types.Service, poller types.Poller, ts int64) {
+	logger := log.WithFields(log.Fields{
+		"timestamp":     ts,
+		"service_id":    service.ServiceID(),
+		"service_type":  service.ServiceType(),
+		"interval_secs": poller.IntervalSecs(),
+	})
+	logger.Info("Starting polling loop")
 	for {
-		if !shouldPoll[service.ServiceID()] {
-			log.WithField("service_id", service.ServiceID()).Info("Terminating poll.")
+		poller.OnPoll(service)
+		if pollTimeChanged(service, ts) {
+			logger.Info("Terminating poll.")
 			break
 		}
-		poller.OnPoll(service)
 		time.Sleep(time.Duration(poller.IntervalSecs()) * time.Second)
+		if pollTimeChanged(service, ts) {
+			logger.Info("Terminating poll.")
+			break
+		}
 	}
+}
+
+// setPollStartTime clobbers the current poll time
+func setPollStartTime(service types.Service, startTs int64) {
+	pollMutex.Lock()
+	defer pollMutex.Unlock()
+	startPollTime[service.ServiceID()] = startTs
+}
+
+// pollTimeChanged returns true if the poll start time for this service ID is different to the one supplied.
+func pollTimeChanged(service types.Service, ts int64) bool {
+	pollMutex.Lock()
+	defer pollMutex.Unlock()
+	return startPollTime[service.ServiceID()] != ts
 }

--- a/src/github.com/matrix-org/go-neb/services/echo/echo.go
+++ b/src/github.com/matrix-org/go-neb/services/echo/echo.go
@@ -4,20 +4,18 @@ import (
 	"github.com/matrix-org/go-neb/matrix"
 	"github.com/matrix-org/go-neb/plugin"
 	"github.com/matrix-org/go-neb/types"
-	"net/http"
 	"strings"
 )
 
 type echoService struct {
+	types.DefaultService
 	id            string
 	serviceUserID string
 }
 
-func (e *echoService) ServiceUserID() string                                          { return e.serviceUserID }
-func (e *echoService) ServiceID() string                                              { return e.id }
-func (e *echoService) ServiceType() string                                            { return "echo" }
-func (e *echoService) Register(oldService types.Service, client *matrix.Client) error { return nil }
-func (e *echoService) PostRegister(oldService types.Service)                          {}
+func (e *echoService) ServiceUserID() string { return e.serviceUserID }
+func (e *echoService) ServiceID() string     { return e.id }
+func (e *echoService) ServiceType() string   { return "echo" }
 func (e *echoService) Plugin(cli *matrix.Client, roomID string) plugin.Plugin {
 	return plugin.Plugin{
 		Commands: []plugin.Command{
@@ -29,9 +27,6 @@ func (e *echoService) Plugin(cli *matrix.Client, roomID string) plugin.Plugin {
 			},
 		},
 	}
-}
-func (e *echoService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
-	w.WriteHeader(200) // Do nothing
 }
 
 func init() {

--- a/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
+++ b/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
@@ -31,6 +31,7 @@ type giphySearch struct {
 }
 
 type giphyService struct {
+	types.DefaultService
 	id            string
 	serviceUserID string
 	APIKey        string // beta key is dc6zaTOxFJmzC
@@ -39,10 +40,6 @@ type giphyService struct {
 func (s *giphyService) ServiceUserID() string { return s.serviceUserID }
 func (s *giphyService) ServiceID() string     { return s.id }
 func (s *giphyService) ServiceType() string   { return "giphy" }
-func (s *giphyService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
-}
-func (s *giphyService) Register(oldService types.Service, client *matrix.Client) error { return nil }
-func (s *giphyService) PostRegister(oldService types.Service)                          {}
 
 func (s *giphyService) Plugin(client *matrix.Client, roomID string) plugin.Plugin {
 	return plugin.Plugin{

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -11,7 +11,6 @@ import (
 	"github.com/matrix-org/go-neb/realms/github"
 	"github.com/matrix-org/go-neb/services/github/client"
 	"github.com/matrix-org/go-neb/types"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -23,6 +22,7 @@ var ownerRepoIssueRegex = regexp.MustCompile(`(([A-z0-9-_]+)/([A-z0-9-_]+))?#([0
 var ownerRepoRegex = regexp.MustCompile(`^([A-z0-9-_]+)/([A-z0-9-_]+)$`)
 
 type githubService struct {
+	types.DefaultService
 	id            string
 	serviceUserID string
 	RealmID       string
@@ -180,9 +180,6 @@ func (s *githubService) Plugin(cli *matrix.Client, roomID string) plugin.Plugin 
 		},
 	}
 }
-func (s *githubService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
-	w.WriteHeader(400)
-}
 
 // Register will create webhooks for the repos specified in Rooms
 //
@@ -211,8 +208,6 @@ func (s *githubService) Register(oldService types.Service, client *matrix.Client
 	log.Infof("%+v", s)
 	return nil
 }
-
-func (s *githubService) PostRegister(oldService types.Service) {}
 
 // defaultRepo returns the default repo for the given room, or an empty string.
 func (s *githubService) defaultRepo(roomID string) string {

--- a/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/matrix"
-	"github.com/matrix-org/go-neb/plugin"
 	"github.com/matrix-org/go-neb/services/github/client"
 	"github.com/matrix-org/go-neb/services/github/webhook"
 	"github.com/matrix-org/go-neb/types"
@@ -17,10 +16,11 @@ import (
 )
 
 type githubWebhookService struct {
+	types.DefaultService
 	id                 string
 	serviceUserID      string
 	webhookEndpointURL string
-	ClientUserID       string // optional; required for webhooks
+	ClientUserID       string
 	RealmID            string
 	SecretToken        string
 	Rooms              map[string]struct { // room_id => {}
@@ -33,9 +33,6 @@ type githubWebhookService struct {
 func (s *githubWebhookService) ServiceUserID() string { return s.serviceUserID }
 func (s *githubWebhookService) ServiceID() string     { return s.id }
 func (s *githubWebhookService) ServiceType() string   { return "github-webhook" }
-func (s *githubWebhookService) Plugin(cli *matrix.Client, roomID string) plugin.Plugin {
-	return plugin.Plugin{}
-}
 func (s *githubWebhookService) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli *matrix.Client) {
 	evType, repo, msg, err := webhook.OnReceiveRequest(req, s.SecretToken)
 	if err != nil {

--- a/src/github.com/matrix-org/go-neb/services/jira/jira.go
+++ b/src/github.com/matrix-org/go-neb/services/jira/jira.go
@@ -24,6 +24,7 @@ var issueKeyRegex = regexp.MustCompile("([A-z]+)-([0-9]+)")
 var projectKeyRegex = regexp.MustCompile("^[A-z]+$")
 
 type jiraService struct {
+	types.DefaultService
 	id                 string
 	serviceUserID      string
 	webhookEndpointURL string
@@ -38,10 +39,9 @@ type jiraService struct {
 	}
 }
 
-func (s *jiraService) ServiceUserID() string                 { return s.serviceUserID }
-func (s *jiraService) ServiceID() string                     { return s.id }
-func (s *jiraService) ServiceType() string                   { return "jira" }
-func (s *jiraService) PostRegister(oldService types.Service) {}
+func (s *jiraService) ServiceUserID() string { return s.serviceUserID }
+func (s *jiraService) ServiceID() string     { return s.id }
+func (s *jiraService) ServiceType() string   { return "jira" }
 func (s *jiraService) Register(oldService types.Service, client *matrix.Client) error {
 	// We only ever make 1 JIRA webhook which listens for all projects and then filter
 	// on receive. So we simply need to know if we need to make a webhook or not. We

--- a/src/github.com/matrix-org/go-neb/services/rss/rss.go
+++ b/src/github.com/matrix-org/go-neb/services/rss/rss.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/matrix"
 	"github.com/matrix-org/go-neb/polling"
 	"github.com/matrix-org/go-neb/types"
@@ -53,26 +54,50 @@ func (s *rssService) Poller() types.Poller  { return &rssPoller{} }
 
 // Register will check the liveness of each RSS feed given. If all feeds check out okay, no error is returned.
 func (s *rssService) Register(oldService types.Service, client *matrix.Client) error {
-	urlSet := make(map[string]bool)
-	for _, roomInfo := range s.Rooms {
-		for u, feedInfo := range roomInfo.Feeds {
-			if feedInfo.PollIntervalMins == 0 {
-				feedInfo.PollIntervalMins = 1
-				log.Print("Set poll interval to 1 ", u)
-			}
-			urlSet[u] = true
+	feeds := feedUrls(s)
+	if len(feeds) == 0 {
+		// this is an error UNLESS the old service had some feeds in which case they are deleting us :(
+		oldFeeds := feedUrls(oldService)
+		if len(oldFeeds) == 0 {
+			return errors.New("An RSS feed must be specified.")
 		}
-	}
-	if len(urlSet) == 0 {
-		log.Print(s.Rooms)
-		return errors.New("An RSS feed must be specified.")
 	}
 	return nil
 }
 
-// PostRegister will start polling
 func (s *rssService) PostRegister(oldService types.Service) {
-	go polling.StartPolling(s, s.Poller())
+	if len(feedUrls(s)) == 0 { // bye-bye :(
+		logger := log.WithFields(log.Fields{
+			"service_id":   s.ServiceID(),
+			"service_type": s.ServiceType(),
+		})
+		logger.Info("Deleting service (0 feeds)")
+		polling.StopPolling(s)
+		if err := database.GetServiceDB().DeleteService(s.ServiceID()); err != nil {
+			logger.WithError(err).Error("Failed to delete service")
+		}
+	}
+}
+
+// feedUrls returns a list of feed urls for this service
+func feedUrls(srv types.Service) []string {
+	var feeds []string
+	s, ok := srv.(*rssService)
+	if !ok {
+		return feeds
+	}
+
+	urlSet := make(map[string]bool)
+	for _, roomInfo := range s.Rooms {
+		for u := range roomInfo.Feeds {
+			urlSet[u] = true
+		}
+	}
+
+	for u := range urlSet {
+		feeds = append(feeds, u)
+	}
+	return feeds
 }
 
 func init() {

--- a/src/github.com/matrix-org/go-neb/services/rss/rss.go
+++ b/src/github.com/matrix-org/go-neb/services/rss/rss.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"github.com/matrix-org/go-neb/matrix"
+	"github.com/matrix-org/go-neb/types"
+)
+
+type rssService struct {
+	types.DefaultService
+	id            string
+	serviceUserID string
+	ClientUserID  string              `json:"client_user_id"`
+	Rooms         map[string]struct { // room_id => {}
+		Feeds map[string]struct { // URL => { }
+			PollIntervalMs int `json:"poll_interval_ms"`
+		} `json:"feeds"`
+	} `json:"rooms"`
+}
+
+func (s *rssService) ServiceUserID() string { return s.serviceUserID }
+func (s *rssService) ServiceID() string     { return s.id }
+func (s *rssService) ServiceType() string   { return "rss" }
+
+// Register will check the liveness of each RSS feed given. If all feeds check out okay, no error is returned.
+func (s *rssService) Register(oldService types.Service, client *matrix.Client) error { return nil }
+
+func init() {
+	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {
+		r := &rssService{
+			id:            serviceID,
+			serviceUserID: serviceUserID,
+		}
+		return r
+	})
+}

--- a/src/github.com/matrix-org/go-neb/services/rss/rss.go
+++ b/src/github.com/matrix-org/go-neb/services/rss/rss.go
@@ -32,7 +32,7 @@ func (p *rssPoller) OnPoll(s types.Service) {
 		}
 	}
 
-	log.Print(rsss.ServiceID()+" Polly poll poll ", rsss.Rooms)
+	// TODO: Some polling
 }
 
 type rssService struct {

--- a/src/github.com/matrix-org/go-neb/services/rss/rss.go
+++ b/src/github.com/matrix-org/go-neb/services/rss/rss.go
@@ -1,28 +1,79 @@
 package services
 
 import (
+	"errors"
+	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/go-neb/matrix"
+	"github.com/matrix-org/go-neb/polling"
 	"github.com/matrix-org/go-neb/types"
+	"time"
 )
+
+type rssPoller struct{}
+
+func (p *rssPoller) IntervalSecs() int64 { return 10 }
+func (p *rssPoller) OnPoll(s types.Service) {
+	rsss, ok := s.(*rssService)
+	if !ok {
+		log.WithField("service_id", s.ServiceID()).Error("RSS: OnPoll called without an RSS Service")
+		return
+	}
+	now := time.Now().Unix() // Second resolution
+	// URL => [ RoomID ]
+	urlsToRooms := make(map[string][]string)
+
+	for roomID, roomInfo := range rsss.Rooms {
+		for u, feedInfo := range roomInfo.Feeds {
+			if feedInfo.LastPollTimestampSecs == 0 || (feedInfo.LastPollTimestampSecs+(int64(feedInfo.PollIntervalMins)*60)) > now {
+				// re-query this feed
+				urlsToRooms[u] = append(urlsToRooms[u], roomID)
+			}
+		}
+	}
+
+	log.Print(rsss.ServiceID()+" Polly poll poll ", rsss.Rooms)
+}
 
 type rssService struct {
 	types.DefaultService
 	id            string
 	serviceUserID string
-	ClientUserID  string              `json:"client_user_id"`
 	Rooms         map[string]struct { // room_id => {}
 		Feeds map[string]struct { // URL => { }
-			PollIntervalMs int `json:"poll_interval_ms"`
-		} `json:"feeds"`
-	} `json:"rooms"`
+			PollIntervalMins      int `json:"poll_interval_mins"`
+			LastPollTimestampSecs int64
+		}
+	}
 }
 
 func (s *rssService) ServiceUserID() string { return s.serviceUserID }
 func (s *rssService) ServiceID() string     { return s.id }
 func (s *rssService) ServiceType() string   { return "rss" }
+func (s *rssService) Poller() types.Poller  { return &rssPoller{} }
 
 // Register will check the liveness of each RSS feed given. If all feeds check out okay, no error is returned.
-func (s *rssService) Register(oldService types.Service, client *matrix.Client) error { return nil }
+func (s *rssService) Register(oldService types.Service, client *matrix.Client) error {
+	urlSet := make(map[string]bool)
+	for _, roomInfo := range s.Rooms {
+		for u, feedInfo := range roomInfo.Feeds {
+			if feedInfo.PollIntervalMins == 0 {
+				feedInfo.PollIntervalMins = 1
+				log.Print("Set poll interval to 1 ", u)
+			}
+			urlSet[u] = true
+		}
+	}
+	if len(urlSet) == 0 {
+		log.Print(s.Rooms)
+		return errors.New("An RSS feed must be specified.")
+	}
+	return nil
+}
+
+// PostRegister will start polling
+func (s *rssService) PostRegister(oldService types.Service) {
+	go polling.StartPolling(s, s.Poller())
+}
 
 func init() {
 	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {


### PR DESCRIPTION
- Services can now return a `Poller` which will be polled at set intervals.
- Services now extend the `DefaultService` so no-op methods can be entirely omitted.
- There is a stub `rssService` which is not currently active.