### PR TITLE
Rejig how feedreaders stores rooms to send updates to

### DIFF
--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -77,5 +77,5 @@ func main() {
 		log.WithError(err).Panic("Failed to start polling")
 	}
 
-	http.ListenAndServe(bindAddress, nil)
+	log.Fatal(http.ListenAndServe(bindAddress, nil))
 }


### PR DESCRIPTION
- Log fatal errors when `ListenAndServe`ing (e.g. port in use).
- Move `Rooms` to inside the `Feed` object.
- Check that there is at least 1 room to send updates to.