### PR TITLE
Move OnPoll into the Service method set

### DIFF
--- a/src/github.com/matrix-org/go-neb/api.go
+++ b/src/github.com/matrix-org/go-neb/api.go
@@ -309,7 +309,7 @@ func (s *configureServiceHandler) OnIncomingRequest(req *http.Request) (interfac
 
 	// Start any polling NOW because they may decide to stop it in PostRegister, and we want to make
 	// sure we'll actually stop.
-	if service.Poller() != nil {
+	if _, ok := service.(types.Poller); ok {
 		if err := polling.StartPolling(service); err != nil {
 			log.WithFields(log.Fields{
 				"service_id": service.ServiceID(),


### PR DESCRIPTION
This feels a lot better because now `OnPoll` works in a similar way to
`OnReceiveWebhook` (called on a `Service`) rather than have this strange
global-per-service-type struct.

This also now prevents waking up a goroutine every 10s as the `OnPoll` interface now returns *when* it wants to next be polled.