### PR TITLE
Add a caching HTTP client

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/die-net/lrucache"
 	"github.com/gregjones/httpcache"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/matrix"
@@ -220,7 +221,8 @@ func itemToHTML(feed *gofeed.Feed, item gofeed.Item) matrix.HTMLMessage {
 }
 
 func init() {
-	cachingClient = httpcache.NewMemoryCacheTransport().Client()
+	lruCache := lrucache.New(1024*1024*20, 0) // 20 MB cache, no max-age
+	cachingClient = httpcache.NewTransport(lruCache).Client()
 	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {
 		r := &rssBotService{
 			id:            serviceID,

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -4,14 +4,18 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/gregjones/httpcache"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/matrix"
 	"github.com/matrix-org/go-neb/polling"
 	"github.com/matrix-org/go-neb/types"
 	"github.com/mmcdole/gofeed"
 	"html"
+	"net/http"
 	"time"
 )
+
+var cachingClient *http.Client
 
 const minPollingIntervalSeconds = 60 // 1 min (News feeds can be genuinely spammy)
 
@@ -50,6 +54,7 @@ func (s *rssBotService) Register(oldService types.Service, client *matrix.Client
 	// Make sure we can parse the feed
 	for feedURL, feedInfo := range s.Feeds {
 		fp := gofeed.NewParser()
+		fp.Client = cachingClient
 		if _, err := fp.ParseURL(feedURL); err != nil {
 			return fmt.Errorf("Failed to read URL %s: %s", feedURL, err.Error())
 		}
@@ -138,6 +143,7 @@ func (s *rssBotService) queryFeed(feedURL string) (*gofeed.Feed, []gofeed.Item, 
 	log.WithField("feed_url", feedURL).Info("Querying feed")
 	var items []gofeed.Item
 	fp := gofeed.NewParser()
+	fp.Client = cachingClient
 	feed, err := fp.ParseURL(feedURL)
 	if err != nil {
 		return nil, items, err
@@ -214,6 +220,7 @@ func itemToHTML(feed *gofeed.Feed, item gofeed.Item) matrix.HTMLMessage {
 }
 
 func init() {
+	cachingClient = httpcache.NewMemoryCacheTransport().Client()
 	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {
 		r := &rssBotService{
 			id:            serviceID,


### PR DESCRIPTION
Most of the RSS feeds I `curl`'d had HTTP cache headers (sometimes to say, don't cache at all, other times to put a low `max-age`), so a generic RFC-compliant HTTP caching library will be Good Enough for our use cases. E.g:

```
> GET /news/rss.xml?edition=uk HTTP/1.1
> Host: feeds.bbci.co.uk
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx
< Content-Type: text/xml; charset=utf-8
< X-Content-Type-Options: nosniff
< x-origin-route: xrt-ext
< Content-Length: 28853
< X-Cache-Action: HIT
< X-Cache-Hits: 2
< X-Cache-Age: 8
< Cache-Control: max-age=51
< Date: Tue, 11 Oct 2016 14:38:24 GMT
< Connection: keep-alive
<
```

I verified that the caching library is doing its job via `tcpdump`, and indeed it seems to be!