### PR TITLE
Add metrics to NEB

### DIFF
--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -5,6 +5,7 @@ import (
 	"github.com/matrix-org/dugong"
 	"github.com/matrix-org/go-neb/clients"
 	"github.com/matrix-org/go-neb/database"
+	_ "github.com/matrix-org/go-neb/metrics"
 	"github.com/matrix-org/go-neb/polling"
 	_ "github.com/matrix-org/go-neb/realms/github"
 	_ "github.com/matrix-org/go-neb/realms/jira"

--- a/src/github.com/matrix-org/go-neb/metrics/metrics.go
+++ b/src/github.com/matrix-org/go-neb/metrics/metrics.go
@@ -9,35 +9,35 @@ type CommandStatus int
 
 // The command status values
 const (
-	Pending CommandStatus = iota
-	Success
-	Failure
+	StatusPending CommandStatus = iota
+	StatusSuccess
+	StatusFailure
 )
 
 var (
-	numIncomingCmds = prometheus.NewCounter(prometheus.CounterOpts{
+	numIncomingCmds = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "num_incoming_commands_total",
 		Help: "The number of incoming commands from matrix clients",
-	})
-	numSuccessCmds = prometheus.NewCounter(prometheus.CounterOpts{
+	}, []string{"cmd"})
+	numSuccessCmds = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "num_success_commands_total",
 		Help: "The number of incoming commands from matrix clients which were successful",
-	})
-	numErrorCmds = prometheus.NewCounter(prometheus.CounterOpts{
+	}, []string{"cmd"})
+	numErrorCmds = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "num_error_commands_total",
 		Help: "The number of incoming commands from matrix clients which failed",
-	})
+	}, []string{"cmd"})
 )
 
-// IncrementCommand increments the incoming command counter (TODO: cmd type)
-func IncrementCommand(st CommandStatus) {
+// IncrementCommand increments the incoming command counter
+func IncrementCommand(cmdName string, st CommandStatus) {
 	switch st {
-	case Pending:
-		numIncomingCmds.Inc()
-	case Success:
-		numSuccessCmds.Inc()
-	case Failure:
-		numErrorCmds.Inc()
+	case StatusPending:
+		numIncomingCmds.With(prometheus.Labels{"cmd": cmdName}).Inc()
+	case StatusSuccess:
+		numSuccessCmds.With(prometheus.Labels{"cmd": cmdName}).Inc()
+	case StatusFailure:
+		numErrorCmds.With(prometheus.Labels{"cmd": cmdName}).Inc()
 	}
 }
 

--- a/src/github.com/matrix-org/go-neb/metrics/metrics.go
+++ b/src/github.com/matrix-org/go-neb/metrics/metrics.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	numIncomingCmds = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "num_incoming_commands_total",
+		Help: "The number of incoming commands from matrix clients",
+	})
+	numSuccessCmds = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "num_success_commands_total",
+		Help: "The number of incoming commands from matrix clients which were successful",
+	})
+	numErrorCmds = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "num_error_commands_total",
+		Help: "The number of incoming commands from matrix clients which failed",
+	})
+)
+
+// IncIncomingCommand increments the incoming command counter (TODO: cmd type)
+func IncIncomingCommand() {
+	numIncomingCmds.Inc()
+}
+
+// IncSuccessCommand increments the success command counter (TODO: cmd type)
+func IncSuccessCommand() {
+	numSuccessCmds.Inc()
+}
+
+// IncErrorCommand increments the error command counter (TODO: cmd type)
+func IncErrorCommand() {
+	numErrorCmds.Inc()
+}
+
+func init() {
+	prometheus.MustRegister(numIncomingCmds)
+	prometheus.MustRegister(numSuccessCmds)
+	prometheus.MustRegister(numErrorCmds)
+}

--- a/src/github.com/matrix-org/go-neb/metrics/metrics.go
+++ b/src/github.com/matrix-org/go-neb/metrics/metrics.go
@@ -4,8 +4,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// CommandStatus is the status of a incoming command
 type CommandStatus int
 
+// The command status values
 const (
 	Pending CommandStatus = iota
 	Success

--- a/src/github.com/matrix-org/go-neb/metrics/metrics.go
+++ b/src/github.com/matrix-org/go-neb/metrics/metrics.go
@@ -4,6 +4,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type CommandStatus int
+
+const (
+	Pending CommandStatus = iota
+	Success
+	Failure
+)
+
 var (
 	numIncomingCmds = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "num_incoming_commands_total",
@@ -19,19 +27,16 @@ var (
 	})
 )
 
-// IncIncomingCommand increments the incoming command counter (TODO: cmd type)
-func IncIncomingCommand() {
-	numIncomingCmds.Inc()
-}
-
-// IncSuccessCommand increments the success command counter (TODO: cmd type)
-func IncSuccessCommand() {
-	numSuccessCmds.Inc()
-}
-
-// IncErrorCommand increments the error command counter (TODO: cmd type)
-func IncErrorCommand() {
-	numErrorCmds.Inc()
+// IncrementCommand increments the incoming command counter (TODO: cmd type)
+func IncrementCommand(st CommandStatus) {
+	switch st {
+	case Pending:
+		numIncomingCmds.Inc()
+	case Success:
+		numSuccessCmds.Inc()
+	case Failure:
+		numErrorCmds.Inc()
+	}
 }
 
 func init() {

--- a/src/github.com/matrix-org/go-neb/plugin/plugin.go
+++ b/src/github.com/matrix-org/go-neb/plugin/plugin.go
@@ -72,7 +72,6 @@ func runCommandForPlugin(plugin Plugin, event *matrix.Event, arguments []string)
 		"user_id": event.Sender,
 		"command": bestMatch.Path,
 	}).Info("Executing command")
-	metrics.IncrementCommand(bestMatch.Path[0], metrics.StatusPending)
 	content, err := bestMatch.Command(event.RoomID, event.Sender, cmdArgs)
 	if err != nil {
 		if content != nil {

--- a/src/github.com/matrix-org/go-neb/plugin/plugin.go
+++ b/src/github.com/matrix-org/go-neb/plugin/plugin.go
@@ -72,7 +72,7 @@ func runCommandForPlugin(plugin Plugin, event *matrix.Event, arguments []string)
 		"user_id": event.Sender,
 		"command": bestMatch.Path,
 	}).Info("Executing command")
-	metrics.IncrementCommand(metrics.Pending)
+	metrics.IncrementCommand(bestMatch.Path[0], metrics.StatusPending)
 	content, err := bestMatch.Command(event.RoomID, event.Sender, cmdArgs)
 	if err != nil {
 		if content != nil {
@@ -84,10 +84,10 @@ func runCommandForPlugin(plugin Plugin, event *matrix.Event, arguments []string)
 				"args":       cmdArgs,
 			}).Warn("Command returned both error and content.")
 		}
-		metrics.IncrementCommand(metrics.Failure)
+		metrics.IncrementCommand(bestMatch.Path[0], metrics.StatusFailure)
 		content = matrix.TextMessage{"m.notice", err.Error()}
 	} else {
-		metrics.IncrementCommand(metrics.Success)
+		metrics.IncrementCommand(bestMatch.Path[0], metrics.StatusSuccess)
 	}
 
 	return content

--- a/src/github.com/matrix-org/go-neb/plugin/plugin.go
+++ b/src/github.com/matrix-org/go-neb/plugin/plugin.go
@@ -72,7 +72,7 @@ func runCommandForPlugin(plugin Plugin, event *matrix.Event, arguments []string)
 		"user_id": event.Sender,
 		"command": bestMatch.Path,
 	}).Info("Executing command")
-	metrics.IncIncomingCommand()
+	metrics.IncrementCommand(metrics.Pending)
 	content, err := bestMatch.Command(event.RoomID, event.Sender, cmdArgs)
 	if err != nil {
 		if content != nil {
@@ -84,10 +84,10 @@ func runCommandForPlugin(plugin Plugin, event *matrix.Event, arguments []string)
 				"args":       cmdArgs,
 			}).Warn("Command returned both error and content.")
 		}
-		metrics.IncErrorCommand()
+		metrics.IncrementCommand(metrics.Failure)
 		content = matrix.TextMessage{"m.notice", err.Error()}
 	} else {
-		metrics.IncSuccessCommand()
+		metrics.IncrementCommand(metrics.Success)
 	}
 
 	return content

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -11,12 +11,20 @@ import (
 	"github.com/matrix-org/go-neb/polling"
 	"github.com/matrix-org/go-neb/types"
 	"github.com/mmcdole/gofeed"
+	"github.com/prometheus/client_golang/prometheus"
 	"html"
 	"net/http"
 	"time"
 )
 
 var cachingClient *http.Client
+
+var (
+	pollCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "goneb_rss_polls_total",
+		Help: "The number of feed polls from RSS services",
+	}, []string{"url", "http_status"})
+)
 
 const minPollingIntervalSeconds = 60 * 5 // 5 min (News feeds can be genuinely spammy)
 
@@ -127,8 +135,15 @@ func (s *rssBotService) OnPoll(cli *matrix.Client) time.Time {
 		feed, items, err := s.queryFeed(u)
 		if err != nil {
 			logger.WithField("feed_url", u).WithError(err).Error("Failed to query feed")
+			herr, ok := err.(gofeed.HTTPError)
+			statusCode := 0 // e.g. network timeout
+			if ok {
+				statusCode = herr.StatusCode
+			}
+			pollCounter.With(prometheus.Labels{"url": u, "http_status": string(statusCode)}).Inc()
 			continue
 		}
+		pollCounter.With(prometheus.Labels{"url": u, "http_status": "200"}).Inc() // technically 2xx but gofeed doesn't tell us which
 		// Loop backwards since [0] is the most recent and we want to send in chronological order
 		for i := len(items) - 1; i >= 0; i-- {
 			item := items[i]
@@ -285,4 +300,5 @@ func init() {
 		}
 		return r
 	})
+	prometheus.MustRegister(pollCounter)
 }

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -136,10 +136,10 @@ func (s *rssBotService) OnPoll(cli *matrix.Client) time.Time {
 		feed, items, err := s.queryFeed(u)
 		if err != nil {
 			logger.WithField("feed_url", u).WithError(err).Error("Failed to query feed")
-			sendMetric(u, err)
+			incrementMetrics(u, err)
 			continue
 		}
-		sendMetric(u, nil)
+		incrementMetrics(u, nil)
 		// Loop backwards since [0] is the most recent and we want to send in chronological order
 		for i := len(items) - 1; i >= 0; i-- {
 			item := items[i]
@@ -161,7 +161,7 @@ func (s *rssBotService) OnPoll(cli *matrix.Client) time.Time {
 	return s.nextTimestamp()
 }
 
-func sendMetric(urlStr string, err error) {
+func incrementMetrics(urlStr string, err error) {
 	// extract domain part of RSS feed URL to get coarser (more useful) statistics
 	domain := urlStr
 	u, urlErr := url.Parse(urlStr)


### PR DESCRIPTION
In addition to the raw HTTP-level metrics, we now increment counters for:
 - Incoming webhook events which are recognised as belonging to a service (add `service_type` as label).
 - Incoming `/configureService` requests which were succesful (add `service_type` as label).
 - Incoming `!command` requests which succeeded/failed (add `status` and `cmd` as labels).
 - Outgoing RSS polls (add `http_status` and `url` as labels).

Also fixed Guggy's bad error handling on non-2xx responses.