### PR TITLE
Prevent panicking code from taking down the entire process

### DIFF
--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -193,9 +193,9 @@ func main() {
 	http.Handle("/metrics", prometheus.Handler())
 	http.Handle("/test", prometheus.InstrumentHandler("test", server.MakeJSONAPI(&heartbeatHandler{})))
 	wh := &webhookHandler{db: db, clients: clients}
-	http.HandleFunc("/services/hooks/", prometheus.InstrumentHandlerFunc("webhookHandler", wh.handle))
+	http.HandleFunc("/services/hooks/", prometheus.InstrumentHandlerFunc("webhookHandler", server.Protect(wh.handle)))
 	rh := &realmRedirectHandler{db: db}
-	http.HandleFunc("/realms/redirects/", prometheus.InstrumentHandlerFunc("realmRedirectHandler", rh.handle))
+	http.HandleFunc("/realms/redirects/", prometheus.InstrumentHandlerFunc("realmRedirectHandler", server.Protect(rh.handle)))
 
 	// Read exclusively from the config file if one was supplied.
 	// Otherwise, add HTTP listeners for new Services/Sessions/Clients/etc.

--- a/src/github.com/matrix-org/go-neb/polling/polling.go
+++ b/src/github.com/matrix-org/go-neb/polling/polling.go
@@ -5,6 +5,7 @@ import (
 	"github.com/matrix-org/go-neb/clients"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/types"
+	"runtime/debug"
 	"sync"
 	"time"
 )
@@ -71,6 +72,15 @@ func pollLoop(service types.Service, ts int64) {
 		"service_id":   service.ServiceID(),
 		"service_type": service.ServiceType(),
 	})
+
+	defer func() {
+		if r := recover(); r != nil {
+			logger.WithField("panic", r).Errorf(
+				"pollLoop panicked!\n%s", debug.Stack(),
+			)
+		}
+	}()
+
 	poller, ok := service.(types.Poller)
 	if !ok {
 		logger.Error("Service is not a Poller.")

--- a/src/github.com/matrix-org/go-neb/polling/polling.go
+++ b/src/github.com/matrix-org/go-neb/polling/polling.go
@@ -74,6 +74,8 @@ func pollLoop(service types.Service, ts int64) {
 	})
 
 	defer func() {
+		// Kill the poll loop entirely as it is likely that whatever made us panic will
+		// make us panic again. We can whine bitterly about it though.
 		if r := recover(); r != nil {
 			logger.WithField("panic", r).Errorf(
 				"pollLoop panicked!\n%s", debug.Stack(),

--- a/src/github.com/matrix-org/go-neb/server/server.go
+++ b/src/github.com/matrix-org/go-neb/server/server.go
@@ -45,7 +45,7 @@ func MakeJSONAPI(handler JSONRequestHandler) http.HandlerFunc {
 		logger.Print("Incoming request")
 		defer func() {
 			if r := recover(); r != nil {
-				logger.WithField("error", r).Errorf(
+				logger.WithField("panic", r).Errorf(
 					"Request panicked!\n%s", debug.Stack(),
 				)
 				jsonErrorResponse(

--- a/src/github.com/matrix-org/go-neb/server/server_test.go
+++ b/src/github.com/matrix-org/go-neb/server/server_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProtect(t *testing.T) {
+	mockWriter := httptest.NewRecorder()
+	mockReq, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	h := Protect(func(w http.ResponseWriter, req *http.Request) {
+		var array []string
+		w.Write([]byte(array[5])) // NPE
+	})
+
+	h(mockWriter, mockReq)
+
+	expectCode := 500
+	if mockWriter.Code != expectCode {
+		t.Errorf("TestProtect wanted HTTP status %d, got %d", expectCode, mockWriter.Code)
+	}
+
+	expectBody := `{"message":"Internal Server Error"}`
+	actualBody := mockWriter.Body.String()
+	if actualBody != expectBody {
+		t.Errorf("TestProtect wanted body %s, got %s", expectBody, actualBody)
+	}
+}


### PR DESCRIPTION
Panicking poll loops and incoming Matrix events could cause the entire process to fall over. They are now protected by a `defer`/`recover` block.

Also, whilst all incoming HTTP requests are, by default, already protected from `panics`, they were falling back to the standard output logger rather than being caught by logrus, so we now catch them in a similar way in order to:
 - Log to logrus.
 - Return a 500 rather than abruptly closing the connection.
 - Return a JSON error response.

Manually tested by introducing NPEs at various points in the code. Fixes #99.