### PR TITLE
Add HTTP API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,72 +108,17 @@ Go-NEB needs to be "configured" with clients and services before it will do anyt
 If you run Go-NEB with a `CONFIG_FILE` environment variable, it will load that file and use it for services, clients, etc. There is a [sample configuration file](config.sample.yaml) which explains all the options. In most cases, these are *direct mappings* to the corresponding HTTP API.
 
 ## Configuring Clients
-Go-NEB needs to connect as a matrix user to receive messages. Go-NEB can listen for messages as multiple matrix users. The users are configured using an HTTP API and the config is stored in the database. To create a user:
-```bash
-curl -X POST localhost:4050/admin/configureClient --data-binary '{
-    "UserID": "@goneb:localhost:8448",
-    "HomeserverURL": "http://localhost:8008",
-    "AccessToken": "<access_token>",
-    "Sync": true,
-    "AutoJoinRooms": true,
-    "DisplayName": "My Bot"
-}'
-```
- - `UserID` is the complete user ID of the client to connect as. The user MUST already exist.
- - `HomeserverURL` is the complete Homeserver URL for the given user ID.
- - `AccessToken` is the user's access token.
- - `Sync`, if `true`, will start a `/sync` stream so this client will receive incoming messages. This is required for services which need a live stream to the server (e.g. to respond to `!commands` and expand issues). It is not required for services which do not respond to Matrix users (e.g. webhook notifications).
- - `AutoJoinRooms`, if `true`, will automatically join rooms when an invite is received. This option is only valid when `Sync: true`.
- - `DisplayName`, if set, will set the given user's profile display name to the string given.
+Go-NEB needs to connect as a matrix user to receive messages. Go-NEB can listen for messages as multiple matrix users. The users are configured using an HTTP API and the config is stored in the database.
 
-Go-NEB will respond with the previous configuration for this client, if one exists, as well as echo back the complete configuration for the client:
-
-```json
-{
-    "OldClient": {},
-    "NewClient": {
-        "UserID": "@goneb:localhost:8448",
-        "HomeserverURL": "http://localhost:8008",
-        "AccessToken": "<access_token>",
-        "Sync": true,
-        "AutoJoinRooms": true,
-        "DisplayName": "My Bot"
-    }
-}
-```
+[http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureClient.OnIncomingRequest](HTTP API Docs)
 
 ## Configuring Services
 Services contain all the useful functionality in Go-NEB. They require a client to operate. Services are configured using an HTTP API and the config is stored in the database. Services use one of the matrix users configured on Go-NEB to send/receive matrix messages.
 
-Every service MUST have the following fields:
- - `Type` : The type of service. This determines which code is executed.
- - `Id` : An arbitrary string which you can use to identify this service.
- - `UserID` : A user ID of a client which has been previously configured on Go-NEB. If this user does not exist, an error will be returned.
- - `Config` : A JSON object. The contents of this object depends on the service.
- 
-The information about a Service can be retrieved based on their `Id` like so:
-```bash
-curl -X POST localhost:4050/admin/getService --data-binary '{
-    "Id": "myserviceid"
-}'
-```
-This will return:
-```yaml
-# HTTP 200 OK
-{
-    "Type": "echo",
-    "Id": "myserviceid",
-    "UserID": "@goneb:localhost:8448",
-    "Config": {}
-}
-```
-If the service is not found, this will return:
-```yaml
-# HTTP 404 Not Found
-{ "message": "Service not found" }
-```
+ - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureService.OnIncomingRequest](Configuring Services (HTTP API))
 
-If you configure an existing Service (based on ID), the entire service will be replaced with the new information.
+ - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#GetService.OnIncomingRequest](Retrieving Services (HTTP API))
+
 
 ### Echo Service
 The simplest service. This will echo back any `!echo` command. To configure one:

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ If you run Go-NEB with a `CONFIG_FILE` environment variable, it will load that f
 ## Configuring Clients
 Go-NEB needs to connect as a matrix user to receive messages. Go-NEB can listen for messages as multiple matrix users. The users are configured using an HTTP API and the config is stored in the database.
 
-[HTTP API Docs](http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureClient.OnIncomingRequest)
+[http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureClient.OnIncomingRequest](HTTP API Docs)
 
 ## Configuring Services
 Services contain all the useful functionality in Go-NEB. They require a client to operate. Services are configured using an HTTP API and the config is stored in the database. Services use one of the matrix users configured on Go-NEB to send/receive matrix messages.
 
- - [Configuring Services (HTTP API)](http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureService.OnIncomingRequest)
+ - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureService.OnIncomingRequest](Configuring Services (HTTP API))
 
- - [Retrieving Services (HTTP API)](http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#GetService.OnIncomingRequest)
+ - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#GetService.OnIncomingRequest](Retrieving Services (HTTP API))
 
 
 ### Echo Service

--- a/README.md
+++ b/README.md
@@ -108,17 +108,72 @@ Go-NEB needs to be "configured" with clients and services before it will do anyt
 If you run Go-NEB with a `CONFIG_FILE` environment variable, it will load that file and use it for services, clients, etc. There is a [sample configuration file](config.sample.yaml) which explains all the options. In most cases, these are *direct mappings* to the corresponding HTTP API.
 
 ## Configuring Clients
-Go-NEB needs to connect as a matrix user to receive messages. Go-NEB can listen for messages as multiple matrix users. The users are configured using an HTTP API and the config is stored in the database.
+Go-NEB needs to connect as a matrix user to receive messages. Go-NEB can listen for messages as multiple matrix users. The users are configured using an HTTP API and the config is stored in the database. To create a user:
+```bash
+curl -X POST localhost:4050/admin/configureClient --data-binary '{
+    "UserID": "@goneb:localhost:8448",
+    "HomeserverURL": "http://localhost:8008",
+    "AccessToken": "<access_token>",
+    "Sync": true,
+    "AutoJoinRooms": true,
+    "DisplayName": "My Bot"
+}'
+```
+ - `UserID` is the complete user ID of the client to connect as. The user MUST already exist.
+ - `HomeserverURL` is the complete Homeserver URL for the given user ID.
+ - `AccessToken` is the user's access token.
+ - `Sync`, if `true`, will start a `/sync` stream so this client will receive incoming messages. This is required for services which need a live stream to the server (e.g. to respond to `!commands` and expand issues). It is not required for services which do not respond to Matrix users (e.g. webhook notifications).
+ - `AutoJoinRooms`, if `true`, will automatically join rooms when an invite is received. This option is only valid when `Sync: true`.
+ - `DisplayName`, if set, will set the given user's profile display name to the string given.
 
-[http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureClient.OnIncomingRequest](HTTP API Docs)
+Go-NEB will respond with the previous configuration for this client, if one exists, as well as echo back the complete configuration for the client:
+
+```json
+{
+    "OldClient": {},
+    "NewClient": {
+        "UserID": "@goneb:localhost:8448",
+        "HomeserverURL": "http://localhost:8008",
+        "AccessToken": "<access_token>",
+        "Sync": true,
+        "AutoJoinRooms": true,
+        "DisplayName": "My Bot"
+    }
+}
+```
 
 ## Configuring Services
 Services contain all the useful functionality in Go-NEB. They require a client to operate. Services are configured using an HTTP API and the config is stored in the database. Services use one of the matrix users configured on Go-NEB to send/receive matrix messages.
 
- - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureService.OnIncomingRequest](Configuring Services (HTTP API))
+Every service MUST have the following fields:
+ - `Type` : The type of service. This determines which code is executed.
+ - `Id` : An arbitrary string which you can use to identify this service.
+ - `UserID` : A user ID of a client which has been previously configured on Go-NEB. If this user does not exist, an error will be returned.
+ - `Config` : A JSON object. The contents of this object depends on the service.
+ 
+The information about a Service can be retrieved based on their `Id` like so:
+```bash
+curl -X POST localhost:4050/admin/getService --data-binary '{
+    "Id": "myserviceid"
+}'
+```
+This will return:
+```yaml
+# HTTP 200 OK
+{
+    "Type": "echo",
+    "Id": "myserviceid",
+    "UserID": "@goneb:localhost:8448",
+    "Config": {}
+}
+```
+If the service is not found, this will return:
+```yaml
+# HTTP 404 Not Found
+{ "message": "Service not found" }
+```
 
- - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#GetService.OnIncomingRequest](Retrieving Services (HTTP API))
-
+If you configure an existing Service (based on ID), the entire service will be replaced with the new information.
 
 ### Echo Service
 The simplest service. This will echo back any `!echo` command. To configure one:

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ If you run Go-NEB with a `CONFIG_FILE` environment variable, it will load that f
 ## Configuring Clients
 Go-NEB needs to connect as a matrix user to receive messages. Go-NEB can listen for messages as multiple matrix users. The users are configured using an HTTP API and the config is stored in the database.
 
-[http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureClient.OnIncomingRequest](HTTP API Docs)
+[HTTP API Docs](http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureClient.OnIncomingRequest)
 
 ## Configuring Services
 Services contain all the useful functionality in Go-NEB. They require a client to operate. Services are configured using an HTTP API and the config is stored in the database. Services use one of the matrix users configured on Go-NEB to send/receive matrix messages.
 
- - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureService.OnIncomingRequest](Configuring Services (HTTP API))
+ - [Configuring Services (HTTP API)](http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#ConfigureService.OnIncomingRequest)
 
- - [http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#GetService.OnIncomingRequest](Retrieving Services (HTTP API))
+ - [Retrieving Services (HTTP API)](http://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/handlers/#GetService.OnIncomingRequest)
 
 
 ### Echo Service

--- a/src/github.com/matrix-org/go-neb/api/api.go
+++ b/src/github.com/matrix-org/go-neb/api/api.go
@@ -76,7 +76,7 @@ type ClientConfig struct {
 	DisplayName string
 }
 
-// Sessions contain the complete auth session information for a given user on a given realm.
+// Session contains the complete auth session information for a given user on a given realm.
 // They are created for use with ConfigFile.
 type Session struct {
 	SessionID string

--- a/src/github.com/matrix-org/go-neb/api/api.go
+++ b/src/github.com/matrix-org/go-neb/api/api.go
@@ -1,7 +1,5 @@
-// Package api contains the fundamental data types used by Go-NEB.
-//
-// Most HTTP API calls and/or config file sections are just ways of representing these
-// data types.
+// Package api contains the fundamental data types used by Go-NEB. Most HTTP API calls
+// and/or config file sections are just ways of representing these data types.
 //
 // See also
 //
@@ -76,7 +74,7 @@ type ClientConfig struct {
 	DisplayName string
 }
 
-// SessionRequests are usually multi-stage things so this type only exists for the config form
+// SessionRequest is usually multi-stage so this type only exists for the config form
 // for use with ConfigFile.
 type SessionRequest struct {
 	SessionID string

--- a/src/github.com/matrix-org/go-neb/api/api.go
+++ b/src/github.com/matrix-org/go-neb/api/api.go
@@ -1,5 +1,7 @@
-// Package api contains the fundamental data types used by Go-NEB. Most HTTP API calls
-// and/or config file sections are just ways of representing these data types.
+// Package api contains the fundamental data types used by Go-NEB.
+//
+// Most HTTP API calls and/or config file sections are just ways of representing these
+// data types.
 //
 // See also
 //
@@ -74,7 +76,7 @@ type ClientConfig struct {
 	DisplayName string
 }
 
-// SessionRequest is usually multi-stage so this type only exists for the config form
+// SessionRequests are usually multi-stage things so this type only exists for the config form
 // for use with ConfigFile.
 type SessionRequest struct {
 	SessionID string

--- a/src/github.com/matrix-org/go-neb/api/handlers/client.go
+++ b/src/github.com/matrix-org/go-neb/api/handlers/client.go
@@ -9,11 +9,36 @@ import (
 	"github.com/matrix-org/go-neb/errors"
 )
 
-// ConfigureClient represents an HTTP handler capable of processing /configureClient requests
+// ConfigureClient represents an HTTP handler capable of processing /admin/configureClient requests.
 type ConfigureClient struct {
 	Clients *clients.Clients
 }
 
+// OnIncomingRequest handles POST requests to /admin/configureClient. The JSON object provided
+// is of type "api.ClientConfig".
+//
+// If a DisplayName is supplied, this request will set this client's display name
+// if the old ClientConfig DisplayName differs from the new ClientConfig DisplayName.
+//
+// Request:
+//  POST /admin/configureClient
+//  {
+//      "UserID": "@my_bot:localhost",
+//      "HomeserverURL": "http://localhost:8008",
+//      "Sync": true,
+//      "DisplayName": "My Bot"
+//  }
+//
+// Response:
+//  HTTP/1.1 200 OK
+//  {
+//       "OldClient": {
+//         // The old api.ClientConfig
+//       },
+//       "NewClient": {
+//         // The new api.ClientConfig
+//       }
+//  }
 func (s *ConfigureClient) OnIncomingRequest(req *http.Request) (interface{}, *errors.HTTPError) {
 	if req.Method != "POST" {
 		return nil, &errors.HTTPError{nil, "Unsupported Method", 405}

--- a/src/github.com/matrix-org/go-neb/api/handlers/heartbeat.go
+++ b/src/github.com/matrix-org/go-neb/api/handlers/heartbeat.go
@@ -1,8 +1,17 @@
+// Package handlers contains the HTTP handlers for Go-NEB.
+//
+// This includes detail on the API paths and top-level JSON keys. For specific service JSON,
+// see the service you're interested in.
+//
+// See also
+//
+// Package "api" for the format of the JSON request bodies.
 package handlers
 
 import (
-	"github.com/matrix-org/go-neb/errors"
 	"net/http"
+
+	"github.com/matrix-org/go-neb/errors"
 )
 
 // Heartbeat implements the heartbeat API
@@ -11,16 +20,12 @@ type Heartbeat struct{}
 // OnIncomingRequest returns an empty JSON object which can be used to detect liveness of Go-NEB.
 //
 // Request:
-// ```
-// GET /test
-// ```
+//  GET /test
+//
 //
 // Response:
-// ```
-// HTTP/1.1 200 OK
-// Content-Type: applicatoin/json
-// {}
-// ```
+//  HTTP/1.1 200 OK
+//  {}
 func (*Heartbeat) OnIncomingRequest(req *http.Request) (interface{}, *errors.HTTPError) {
 	return &struct{}{}, nil
 }

--- a/src/github.com/matrix-org/go-neb/api/handlers/service.go
+++ b/src/github.com/matrix-org/go-neb/api/handlers/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/matrix-org/go-neb/types"
 )
 
+// ConfigureService represents an HTTP handler which can process /admin/configureService requests.
 type ConfigureService struct {
 	db               *database.ServiceDB
 	clients          *clients.Clients
@@ -23,6 +24,7 @@ type ConfigureService struct {
 	mutexByServiceID map[string]*sync.Mutex
 }
 
+// NewConfigureService creates a new ConfigureService handler
 func NewConfigureService(db *database.ServiceDB, clients *clients.Clients) *ConfigureService {
 	return &ConfigureService{
 		db:               db,
@@ -45,6 +47,32 @@ func (s *ConfigureService) getMutexForServiceID(serviceID string) *sync.Mutex {
 	return m
 }
 
+// OnIncomingRequest handles POST requests to /admin/configureService.
+//
+// The request body MUST be of type "api.ConfigureServiceRequest".
+//
+// Request:
+//  POST /admin/configureService
+//  {
+//      "ID": "my_service_id",
+//      "Type": "service-type",
+//      "UserID": "@my_bot:localhost",
+//      "Config": {
+//          // service-specific config information
+//      }
+//  }
+// Response:
+//  HTTP/1.1 200 OK
+//  {
+//      "ID": "my_service_id",
+//      "Type": "service-type",
+//      "OldConfig": {
+//          // old service-specific config information
+//      },
+//      "NewConfig": {
+//          // new service-specific config information
+//      },
+//  }
 func (s *ConfigureService) OnIncomingRequest(req *http.Request) (interface{}, *errors.HTTPError) {
 	if req.Method != "POST" {
 		return nil, &errors.HTTPError{nil, "Unsupported Method", 405}
@@ -123,10 +151,30 @@ func (s *ConfigureService) createService(req *http.Request) (types.Service, *err
 	return service, nil
 }
 
+// GetService represents an HTTP handler which can process /admin/getService requests.
 type GetService struct {
 	Db *database.ServiceDB
 }
 
+// OnIncomingRequest handles POST requests to /admin/getService.
+//
+// The request body MUST be a JSON body which has an "ID" key which represents
+// the service ID to get.
+//
+// Request:
+//  POST /admin/getService
+//  {
+//      "ID": "my_service_id"
+//  }
+// Response:
+//  HTTP/1.1 200 OK
+//  {
+//      "ID": "my_service_id",
+//      "Type": "github",
+//      "Config": {
+//          // service-specific config information
+//      }
+//  }
 func (h *GetService) OnIncomingRequest(req *http.Request) (interface{}, *errors.HTTPError) {
 	if req.Method != "POST" {
 		return nil, &errors.HTTPError{nil, "Unsupported Method", 405}

--- a/src/github.com/matrix-org/go-neb/api/handlers/webhook.go
+++ b/src/github.com/matrix-org/go-neb/api/handlers/webhook.go
@@ -2,12 +2,13 @@ package handlers
 
 import (
 	"encoding/base64"
+	"net/http"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/go-neb/clients"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/metrics"
-	"net/http"
-	"strings"
 )
 
 // Webhook represents an HTTP handler capable of accepting webhook requests on behalf of services.
@@ -24,7 +25,9 @@ func NewWebhook(db *database.ServiceDB, cli *clients.Clients) *Webhook {
 // Handle an incoming webhook HTTP request.
 //
 // The webhook MUST have a known base64 encoded service ID as the last path segment
-// in order for this request to be passed to the correct service.
+// in order for this request to be passed to the correct service, or else this will return
+// HTTP 400. If the base64 encoded service ID is unknown, this will return HTTP 404.
+// Beyond this, the exact response is determined by the specific Service implementation.
 func (wh *Webhook) Handle(w http.ResponseWriter, req *http.Request) {
 	log.WithField("path", req.URL.Path).Print("Incoming webhook request")
 	segments := strings.Split(req.URL.Path, "/")


### PR DESCRIPTION
This all gets formatted correctly by `godoc`. There is no hosted version of these docs yet (on GH-Pages, godoc.org, or otherwise) hence I have not removed the docs in the README yet.