### PR TITLE
Add default implementations for ServiceType(), ServiceID() and ServiceUserID()

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
+++ b/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/matrix-org/go-neb/types"
 )
 
+// ServiceType of the Giphy service
 const ServiceType = "giphy"
 
 type result struct {
@@ -38,17 +39,14 @@ type giphySearch struct {
 // Service contains the Config fields for this service.
 type Service struct {
 	types.DefaultService
-	id            string
-	serviceUserID string
 	// The Giphy API key to use when making HTTP requests to Giphy. The public beta
 	// API key is "dc6zaTOxFJmzC".
 	APIKey string `json:"api_key"`
 }
 
-func (s *Service) ServiceUserID() string { return s.serviceUserID }
-func (s *Service) ServiceID() string     { return s.id }
-func (s *Service) ServiceType() string   { return ServiceType }
-
+// Commands supported:
+//   !giphy some search query without quotes
+// Responds with a suitable GIF into the same room as the command.
 func (s *Service) Commands(client *matrix.Client, roomID string) []types.Command {
 	return []types.Command{
 		types.Command{
@@ -59,6 +57,7 @@ func (s *Service) Commands(client *matrix.Client, roomID string) []types.Command
 		},
 	}
 }
+
 func (s *Service) cmdGiphy(client *matrix.Client, roomID, userID string, args []string) (interface{}, error) {
 	// only 1 arg which is the text to search for.
 	query := strings.Join(args, " ")
@@ -123,8 +122,7 @@ func asInt(strInt string) uint {
 func init() {
 	types.RegisterService(func(serviceID, serviceUserID, webhookEndpointURL string) types.Service {
 		return &Service{
-			id:            serviceID,
-			serviceUserID: serviceUserID,
+			DefaultService: types.NewDefaultService(serviceID, serviceUserID, ServiceType),
 		}
 	})
 }

--- a/src/github.com/matrix-org/go-neb/types/service.go
+++ b/src/github.com/matrix-org/go-neb/types/service.go
@@ -50,7 +50,32 @@ type Service interface {
 }
 
 // DefaultService NO-OPs the implementation of optional Service interface methods. Feel free to override them.
-type DefaultService struct{}
+type DefaultService struct {
+	id            string
+	serviceUserID string
+	serviceType   string
+}
+
+// NewDefaultService creates a new service with implementations for ServiceID(), ServiceType() and ServiceUserID()
+func NewDefaultService(serviceID, serviceUserID, serviceType string) DefaultService {
+	return DefaultService{serviceID, serviceUserID, serviceType}
+}
+
+// ServiceID returns the service's ID.
+func (s *DefaultService) ServiceID() string {
+	return s.id
+}
+
+// ServiceUserID returns the user ID that the service sends events as.
+func (s *DefaultService) ServiceUserID() string {
+	return s.serviceUserID
+}
+
+// ServiceType returns the type of service. See each individual service package for the ServiceType constant
+// to find out what this value actually is.
+func (s *DefaultService) ServiceType() string {
+	return s.serviceType
+}
 
 // Commands returns no commands.
 func (s *DefaultService) Commands(cli *matrix.Client, roomID string) []Command {


### PR DESCRIPTION
In addition to making there be less boilerplate, this also has the nice side-effect of shutting up golint warnings \o/

Will convert the rest of the services once this format has been OKed.