### PR TITLE
Use a text formatter which logs as key=val instead of JSON

### DIFF
--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -227,7 +227,12 @@ func main() {
 			filepath.Join(e.LogDir, "info.log"),
 			filepath.Join(e.LogDir, "warn.log"),
 			filepath.Join(e.LogDir, "error.log"),
-			nil, &dugong.DailyRotationSchedule{GZip: true},
+			&log.TextFormatter{
+				TimestampFormat:  "2006-01-02 15:04:05.000000",
+				DisableColors:    true,
+				DisableTimestamp: false,
+				DisableSorting:   false,
+			}, &dugong.DailyRotationSchedule{GZip: true},
 		))
 	}
 


### PR DESCRIPTION
We exclusively view logs using `less` and `tail`. These do not read JSON well.
Logging as JSON makes it a PITA to read logs and debug problems. We do not
appear to make use of JSON logging, and have no good terminal-based
structured log viewer either.

As a result, I've now removed JSON logging from this project and replaced it
with the standard `TextFormatter` (colors off). This still logs in a structured
way:

```
time="2016-11-18 16:25:46.787373" level=info msg="Got filter ID" filter=717 syncing=1 user_id="@goneb:localhost"
time="2016-11-18 16:25:46.787525" level=info msg="Starting sync" next_batch="s26928_287972_2_1029_26_1_2" syncing=1 user_id="@goneb:localhost"
```

So we can still analyse logs sanely at a later date should we need to. This
feels like the best compromise here between pragmatism and ideals.