### PR TITLE
Add a dedicated testutils package

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/guggy/guggy_test.go
+++ b/src/github.com/matrix-org/go-neb/services/guggy/guggy_test.go
@@ -23,8 +23,7 @@ func TestCommand(t *testing.T) {
 	guggyImageURL := "https://guggy.com/gifs/23ryf872fg"
 
 	// Mock the response from Guggy
-	guggyTrans := struct{ testutils.MockTransport }{}
-	guggyTrans.RT = func(req *http.Request) (*http.Response, error) {
+	guggyTrans := testutils.NewRoundTripper(func(req *http.Request) (*http.Response, error) {
 		guggyURL := "https://text2gif.guggy.com/guggify"
 		if req.URL.String() != guggyURL {
 			t.Fatalf("Bad URL: got %s want %s", req.URL.String(), guggyURL)
@@ -58,7 +57,7 @@ func TestCommand(t *testing.T) {
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBuffer(b)),
 		}, nil
-	}
+	})
 	// clobber the guggy service http client instance
 	httpClient = &http.Client{Transport: guggyTrans}
 

--- a/src/github.com/matrix-org/go-neb/services/guggy/guggy_test.go
+++ b/src/github.com/matrix-org/go-neb/services/guggy/guggy_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/matrix-org/go-neb/database"
 	"github.com/matrix-org/go-neb/matrix"
+	"github.com/matrix-org/go-neb/testutils"
 	"github.com/matrix-org/go-neb/types"
 	"io/ioutil"
 	"net/http"
@@ -13,14 +14,6 @@ import (
 	"strings"
 	"testing"
 )
-
-type MockTransport struct {
-	roundTrip func(*http.Request) (*http.Response, error)
-}
-
-func (t MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return t.roundTrip(req)
-}
 
 // TODO: It would be nice to tabularise this test so we can try failing different combinations of responses to make
 //       sure all cases are handled, rather than just the general case as is here.
@@ -30,8 +23,8 @@ func TestCommand(t *testing.T) {
 	guggyImageURL := "https://guggy.com/gifs/23ryf872fg"
 
 	// Mock the response from Guggy
-	guggyTrans := struct{ MockTransport }{}
-	guggyTrans.roundTrip = func(req *http.Request) (*http.Response, error) {
+	guggyTrans := struct{ testutils.MockTransport }{}
+	guggyTrans.RT = func(req *http.Request) (*http.Response, error) {
 		guggyURL := "https://text2gif.guggy.com/guggify"
 		if req.URL.String() != guggyURL {
 			t.Fatalf("Bad URL: got %s want %s", req.URL.String(), guggyURL)
@@ -79,8 +72,8 @@ func TestCommand(t *testing.T) {
 	guggy := srv.(*Service)
 
 	// Mock the response from Matrix
-	matrixTrans := struct{ MockTransport }{}
-	matrixTrans.roundTrip = func(req *http.Request) (*http.Response, error) {
+	matrixTrans := struct{ testutils.MockTransport }{}
+	matrixTrans.RT = func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() == guggyImageURL { // getting the guggy image
 			return &http.Response{
 				StatusCode: 200,

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot_test.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot_test.go
@@ -41,8 +41,7 @@ func TestHTMLEntities(t *testing.T) {
 	database.SetServiceDB(&database.NopStorage{})
 	feedURL := "https://thehappymaskshop.hyrule"
 	// Replace the cachingClient with a mock so we can intercept RSS requests
-	rssTrans := struct{ testutils.MockTransport }{}
-	rssTrans.RT = func(req *http.Request) (*http.Response, error) {
+	rssTrans := testutils.NewRoundTripper(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != feedURL {
 			return nil, errors.New("Unknown test URL")
 		}
@@ -50,7 +49,7 @@ func TestHTMLEntities(t *testing.T) {
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBufferString(rssFeedXML)),
 		}, nil
-	}
+	})
 	cachingClient = &http.Client{Transport: rssTrans}
 
 	// Create the RSS service

--- a/src/github.com/matrix-org/go-neb/services/travisci/travisci_test.go
+++ b/src/github.com/matrix-org/go-neb/services/travisci/travisci_test.go
@@ -99,8 +99,7 @@ func TestTravisCI(t *testing.T) {
 	urlToKey := make(map[string]string)
 	urlToKey["https://api.travis-ci.org/config"] = travisOrgPEMPublicKey
 	urlToKey["https://api.travis-ci.com/config"] = travisComPEMPublicKey
-	travisTransport := struct{ testutils.MockTransport }{}
-	travisTransport.RT = func(req *http.Request) (*http.Response, error) {
+	travisTransport := testutils.NewRoundTripper(func(req *http.Request) (*http.Response, error) {
 		if key := urlToKey[req.URL.String()]; key != "" {
 			escKey, _ := json.Marshal(key)
 			return &http.Response{
@@ -111,7 +110,7 @@ func TestTravisCI(t *testing.T) {
 			}, nil
 		}
 		return nil, fmt.Errorf("Unhandled URL %s", req.URL.String())
-	}
+	})
 	// clobber the http client that the service uses to talk to Travis
 	httpClient = &http.Client{Transport: travisTransport}
 

--- a/src/github.com/matrix-org/go-neb/testutils/testutils.go
+++ b/src/github.com/matrix-org/go-neb/testutils/testutils.go
@@ -6,10 +6,23 @@ import (
 
 // MockTransport implements RoundTripper
 type MockTransport struct {
+	// RT is the RoundTrip function. Replace this function with your test function.
+	// For example:
+	//   t := MockTransport{}
+	//   t.RT = func(req *http.Request) (*http.Response, error) {
+	//       // assert req args, return res or error
+	//   }
 	RT func(*http.Request) (*http.Response, error)
 }
 
 // RoundTrip is a RoundTripper
 func (t MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.RT(req)
+}
+
+// NewRoundTripper returns a new RoundTripper which will call the provided function.
+func NewRoundTripper(roundTrip func(*http.Request) (*http.Response, error)) http.RoundTripper {
+	rt := MockTransport{}
+	rt.RT = roundTrip
+	return rt
 }

--- a/src/github.com/matrix-org/go-neb/testutils/testutils.go
+++ b/src/github.com/matrix-org/go-neb/testutils/testutils.go
@@ -1,0 +1,15 @@
+package testutils
+
+import (
+	"net/http"
+)
+
+// MockTransport implements RoundTripper
+type MockTransport struct {
+	RT func(*http.Request) (*http.Response, error)
+}
+
+// RoundTrip is a RoundTripper
+func (t MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.RT(req)
+}


### PR DESCRIPTION
In the spirit of "if you have to do something 3 times then factor it
out", make a testutils package to put all the `RoundTrip` boilerplate.

I don't overly like having test packages, especially mixed in with
code, but I don't see a nicer way of doing this without ending up
with a sprawling mess of copypasta'd test boilerplate which will
be an absolute nightmare to maintain. This is only going to get
worse as I want to add more tests with exactly this API shape.

I think this is the lesser of two evils.