### PR TITLE
Treat RSS feeds with 0 items as errors

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -243,7 +243,11 @@ func (s *Service) queryFeed(feedURL string) (*gofeed.Feed, []gofeed.Item, error)
 	feed, err := fp.ParseURL(feedURL)
 	// check for no items in addition to any returned errors as it appears some RSS feeds
 	// do not consistently return items.
-	if err != nil || len(feed.Items) == 0 {
+	if err == nil && len(feed.Items) == 0 {
+		err = errors.New("feed has 0 items")
+	}
+
+	if err != nil {
 		f := s.Feeds[feedURL]
 		f.IsFailing = true
 		s.Feeds[feedURL] = f

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -241,7 +241,9 @@ func (s *Service) queryFeed(feedURL string) (*gofeed.Feed, []gofeed.Item, error)
 	fp := gofeed.NewParser()
 	fp.Client = cachingClient
 	feed, err := fp.ParseURL(feedURL)
-	if err != nil {
+	// check for no items in addition to any returned errors as it appears some RSS feeds
+	// do not consistently return items.
+	if err != nil || len(feed.Items) == 0 {
 		f := s.Feeds[feedURL]
 		f.IsFailing = true
 		s.Feeds[feedURL] = f


### PR DESCRIPTION
In the wild it looks like some RSS feeds will occasionally return 0 items
to requests *but not return an error*. This previously meant we would clobber
our knowledge of recent GUIDs with the empty set. This meant that the next
successful poll would resend the **entire** RSS feed.

This patch fixes it by treating 0 items as failures and acting accordingly.

May fix https://github.com/matrix-org/go-neb/issues/133