### PR TITLE
Do not use log field names 'level', 'msg' or 'time'

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
@@ -107,7 +107,7 @@ func (s *WebhookService) OnReceiveWebhook(w http.ResponseWriter, req *http.Reque
 			}
 			if notifyRoom {
 				logger.WithFields(log.Fields{
-					"msg":     msg,
+					"message":     msg,
 					"room_id": roomID,
 				}).Print("Sending notification to room")
 				if _, e := cli.SendMessageEvent(roomID, "m.room.message", msg); e != nil {

--- a/src/github.com/matrix-org/go-neb/services/travisci/travisci.go
+++ b/src/github.com/matrix-org/go-neb/services/travisci/travisci.go
@@ -228,7 +228,7 @@ func (s *Service) OnReceiveWebhook(w http.ResponseWriter, req *http.Request, cli
 			}
 
 			logger.WithFields(log.Fields{
-				"msg":     msg,
+				"message":     msg,
 				"room_id": roomID,
 			}).Print("Sending Travis-CI notification to room")
 			if _, e := cli.SendMessageEvent(roomID, "m.room.message", msg); e != nil {


### PR DESCRIPTION
By default logrus uses these keys. If we also define one, logrus detects this
and then works around by adding 'fields.whatever' as the key name. However,
in the process of adding the key to the `Fields` it causes a race condition
which can crash the process with concurrent map r/w errors.

Fixes #146