### PR TITLE
Add ability to use downsized images from giphy

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -67,6 +67,7 @@ services:
     UserID: "@goneb:localhost" # requires a Syncing client
     Config:
       api_key: "qwg4672vsuyfsfe"
+      use_downsized: false
 
   - ID: "guggy_service"
     Type: "guggy"


### PR DESCRIPTION
The raw, original GIFs returned from giphy can sometimes be quite large (>2MB is not uncommon). giphy provides a `downsized` image designed to be <2MB, which will result in:
* less storage space used on the Matrix server (since the GIF is uploaded to the media repository)
* less bandwidth used to deliver the GIF

For what it's worth (maybe nothing), the giphy/Slack integration appears to use downsized images by default.

I added an option in order to keep the current behavior without any required changes.

This is my first golang code, so of course feel free to critique as necessary. I'm more than happy to make any changes!