### PR TITLE
fix race condition in doc generation

### DIFF
--- a/gendoc.sh
+++ b/gendoc.sh
@@ -9,13 +9,10 @@ GOPATH=$(pwd):$(pwd)/vendor godoc -http=localhost:6060 &
 DOC_PID=$!
 
 # Wait for the server to init
-while :
+until curl -s "http://localhost:6060" > /dev/null
 do
-    curl -s "http://localhost:6060" > /dev/null
-    if [ $? -eq 0 ] # exit code is 0 if we connected
-    then
-        break
-    fi
+    # no-op
+    :
 done
 
 # Scrape the pkg directory for the API docs. Scrap lib for the CSS/JS. Ignore everything else.

--- a/gendoc.sh
+++ b/gendoc.sh
@@ -9,7 +9,7 @@ GOPATH=$(pwd):$(pwd)/vendor godoc -http=localhost:6060 &
 DOC_PID=$!
 
 # Wait for the server to init
-until curl -s "http://localhost:6060" > /dev/null
+until curl -fs "http://localhost:6060/pkg/github.com/matrix-org/go-neb/" > /dev/null
 do
     # no-op
     :


### PR DESCRIPTION
Hi,

at least on my system ./gendoc.sh aborts because of a race condition between getting the gendoc server up and getting the gendoc server serve content. This fixes the curl that should have prevented it.

Signed-off-by: Simon Körner github@lubiland.de