### PR TITLE
Log alertmanager errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 vendor/pkg
 vendor/src
 pkg
-hooks
 bin
 .git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
- - 1.7
+ - 1.11
 install:
  - go get github.com/constabulary/gb/...
  - go get github.com/golang/lint/golint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 # Build go-neb
-FROM golang:1.10-alpine as builder
+FROM golang:1.11-alpine as builder
+
+RUN apk add --no-cache -t build-deps git gcc musl-dev go
 
 COPY . /tmp/go-neb
 WORKDIR /tmp/go-neb
-RUN apk add --no-cache -t build-deps git gcc musl-dev go \
-    && go get -u github.com/constabulary/gb/... \
+RUN go get -u github.com/constabulary/gb/... \
+    && go get github.com/golang/lint/golint \
+    && go get github.com/fzipp/gocyclo \
     && gb vendor restore \
     && gb build -f github.com/matrix-org/go-neb
 
+# Ensures we're lint-free
+RUN /tmp/go-neb/hooks/pre-commit
 
 # Run go-neb
 FROM alpine:3.7

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 
 set -eu
 

--- a/src/github.com/matrix-org/go-neb/goneb.go
+++ b/src/github.com/matrix-org/go-neb/goneb.go
@@ -172,15 +172,15 @@ func setup(e envVars, mux *http.ServeMux, matrixClient *http.Client) {
 		log.Info("Inserted ", len(cfg.Sessions), " sessions")
 	}
 
-	clients := clients.New(db, matrixClient)
-	if err := clients.Start(); err != nil {
+	matrixClients := clients.New(db, matrixClient)
+	if err := matrixClients.Start(); err != nil {
 		log.WithError(err).Panic("Failed to start up clients")
 	}
 
 	// Handle non-admin paths for normal NEB functioning
 	mux.Handle("/metrics", prometheus.Handler())
 	mux.Handle("/test", prometheus.InstrumentHandler("test", util.MakeJSONAPI(&handlers.Heartbeat{})))
-	wh := handlers.NewWebhook(db, clients)
+	wh := handlers.NewWebhook(db, matrixClients)
 	mux.HandleFunc("/services/hooks/", prometheus.InstrumentHandlerFunc("webhookHandler", util.Protect(wh.Handle)))
 	rh := &handlers.RealmRedirect{db}
 	mux.HandleFunc("/realms/redirects/", prometheus.InstrumentHandlerFunc("realmRedirectHandler", util.Protect(rh.Handle)))
@@ -188,7 +188,7 @@ func setup(e envVars, mux *http.ServeMux, matrixClient *http.Client) {
 	// Read exclusively from the config file if one was supplied.
 	// Otherwise, add HTTP listeners for new Services/Sessions/Clients/etc.
 	if e.ConfigFile != "" {
-		if err := insertServicesFromConfig(clients, cfg.Services); err != nil {
+		if err := insertServicesFromConfig(matrixClients, cfg.Services); err != nil {
 			log.WithError(err).Panic("Failed to insert services")
 		}
 
@@ -196,13 +196,13 @@ func setup(e envVars, mux *http.ServeMux, matrixClient *http.Client) {
 	} else {
 		mux.Handle("/admin/getService", prometheus.InstrumentHandler("getService", util.MakeJSONAPI(&handlers.GetService{db})))
 		mux.Handle("/admin/getSession", prometheus.InstrumentHandler("getSession", util.MakeJSONAPI(&handlers.GetSession{db})))
-		mux.Handle("/admin/configureClient", prometheus.InstrumentHandler("configureClient", util.MakeJSONAPI(&handlers.ConfigureClient{clients})))
-		mux.Handle("/admin/configureService", prometheus.InstrumentHandler("configureService", util.MakeJSONAPI(handlers.NewConfigureService(db, clients))))
+		mux.Handle("/admin/configureClient", prometheus.InstrumentHandler("configureClient", util.MakeJSONAPI(&handlers.ConfigureClient{matrixClients})))
+		mux.Handle("/admin/configureService", prometheus.InstrumentHandler("configureService", util.MakeJSONAPI(handlers.NewConfigureService(db, matrixClients))))
 		mux.Handle("/admin/configureAuthRealm", prometheus.InstrumentHandler("configureAuthRealm", util.MakeJSONAPI(&handlers.ConfigureAuthRealm{db})))
 		mux.Handle("/admin/requestAuthSession", prometheus.InstrumentHandler("requestAuthSession", util.MakeJSONAPI(&handlers.RequestAuthSession{db})))
 		mux.Handle("/admin/removeAuthSession", prometheus.InstrumentHandler("removeAuthSession", util.MakeJSONAPI(&handlers.RemoveAuthSession{db})))
 	}
-	polling.SetClients(clients)
+	polling.SetClients(matrixClients)
 	if err := polling.Start(); err != nil {
 		log.WithError(err).Panic("Failed to start polling")
 	}

--- a/src/github.com/matrix-org/go-neb/realms/jira/jira.go
+++ b/src/github.com/matrix-org/go-neb/realms/jira/jira.go
@@ -165,7 +165,7 @@ func (r *Realm) Init() error {
 // Register is called when this realm is being created from an external entity
 func (r *Realm) Register() error {
 	if r.ConsumerName == "" || r.ConsumerKey == "" || r.ConsumerSecret == "" || r.PrivateKeyPEM == "" {
-		return errors.New("ConsumerName, ConsumerKey, ConsumerSecret, PrivateKeyPEM must be specified.")
+		return errors.New("ConsumerName, ConsumerKey, ConsumerSecret, PrivateKeyPEM must be specified")
 	}
 	if r.JIRAEndpoint == "" {
 		return errors.New("JIRAEndpoint must be specified")

--- a/src/github.com/matrix-org/go-neb/services/alertmanager/alertmanager.go
+++ b/src/github.com/matrix-org/go-neb/services/alertmanager/alertmanager.go
@@ -125,15 +125,14 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 		// validate that we have at least a plain text template
 		if templates.TextTemplate == "" {
 			return fmt.Errorf("plain text template missing")
+		} else {
+			// validate the plain text template is valid
+			_, err := text.New("textTemplate").Parse(templates.TextTemplate)
+			if err != nil {
+				log.WithError(err).Print("plain text template error")
+				return fmt.Errorf("plain text template is invalid")
+			}
 		}
-
-		// validate the plain text template is valid
-		_, err := text.New("textTemplate").Parse(templates.TextTemplate)
-		if err != nil {
-			log.WithError(err).Print("plain text template error")
-			return fmt.Errorf("plain text template is invalid")
-		}
-
 		if templates.HTMLTemplate != "" {
 			// validate that the html template is valid
 			_, err := html.New("htmlTemplate").Parse(templates.HTMLTemplate)

--- a/src/github.com/matrix-org/go-neb/services/alertmanager/alertmanager.go
+++ b/src/github.com/matrix-org/go-neb/services/alertmanager/alertmanager.go
@@ -130,6 +130,7 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 		// validate the plain text template is valid
 		_, err := text.New("textTemplate").Parse(templates.TextTemplate)
 		if err != nil {
+			log.WithError(err).Print("plain text template error")
 			return fmt.Errorf("plain text template is invalid")
 		}
 
@@ -137,6 +138,7 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 			// validate that the html template is valid
 			_, err := html.New("htmlTemplate").Parse(templates.HTMLTemplate)
 			if err != nil {
+				log.WithError(err).Print("html template error")
 				return fmt.Errorf("html template is invalid")
 			}
 		}

--- a/src/github.com/matrix-org/go-neb/services/alertmanager/alertmanager.go
+++ b/src/github.com/matrix-org/go-neb/services/alertmanager/alertmanager.go
@@ -52,7 +52,7 @@ type Service struct {
 	} `json:"rooms"`
 }
 
-// The payload from Alertmanager
+// WebhookNotification is the payload from Alertmanager
 type WebhookNotification struct {
 	Version           string            `json:"version"`
 	GroupKey          string            `json:"groupKey"`
@@ -61,14 +61,14 @@ type WebhookNotification struct {
 	GroupLabels       map[string]string `json:"groupLabels"`
 	CommonLabels      map[string]string `json:"commonLabels"`
 	CommonAnnotations map[string]string `json:"commonAnnotations"`
-	ExternalUrl       string            `json:"externalURL"`
+	ExternalURL       string            `json:"externalURL"`
 	Alerts            []struct {
 		Status       string            `json:"status"`
 		Labels       map[string]string `json:"labels"`
 		Annotations  map[string]string `json:"annotations"`
 		StartsAt     string            `json:"startsAt"`
 		EndsAt       string            `json:"endsAt"`
-		GeneratorUrl string            `json:"generatorURL"`
+		GeneratorURL string            `json:"generatorURL"`
 	} `json:"alerts"`
 }
 
@@ -125,13 +125,14 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 		// validate that we have at least a plain text template
 		if templates.TextTemplate == "" {
 			return fmt.Errorf("plain text template missing")
-		} else {
-			// validate the plain text template is valid
-			_, err := text.New("textTemplate").Parse(templates.TextTemplate)
-			if err != nil {
-				return fmt.Errorf("plain text template is invalid")
-			}
 		}
+
+		// validate the plain text template is valid
+		_, err := text.New("textTemplate").Parse(templates.TextTemplate)
+		if err != nil {
+			return fmt.Errorf("plain text template is invalid")
+		}
+
 		if templates.HTMLTemplate != "" {
 			// validate that the html template is valid
 			_, err := html.New("htmlTemplate").Parse(templates.HTMLTemplate)

--- a/src/github.com/matrix-org/go-neb/services/github/github.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github.go
@@ -460,9 +460,9 @@ func (s *Service) expandCommit(roomID, userID, owner, repo, sha string) interfac
 	var htmlBuffer bytes.Buffer
 	var plainBuffer bytes.Buffer
 
-	shortUrl := strings.TrimSuffix(*c.HTMLURL, *c.SHA) + sha
-	htmlBuffer.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a><br />", *c.HTMLURL, shortUrl))
-	plainBuffer.WriteString(fmt.Sprintf("%s\n", shortUrl))
+	shortURL := strings.TrimSuffix(*c.HTMLURL, *c.SHA) + sha
+	htmlBuffer.WriteString(fmt.Sprintf("<a href=\"%s\">%s</a><br />", *c.HTMLURL, shortURL))
+	plainBuffer.WriteString(fmt.Sprintf("%s\n", shortURL))
 
 	if c.Stats != nil {
 		htmlBuffer.WriteString(fmt.Sprintf("[<strong><font color='#1cc3ed'>~%d</font>, <font color='#30bf2b'>+%d</font>, <font color='#fc3a25'>-%d</font></strong>] ", len(c.Files), *c.Stats.Additions, *c.Stats.Deletions))
@@ -744,7 +744,7 @@ func getTokenForUser(realmID, userID string) (string, error) {
 		return "", fmt.Errorf("Session is not a github session: %s", session.ID())
 	}
 	if ghSession.AccessToken == "" {
-		return "", fmt.Errorf("Github auth session for %s has not been completed.", userID)
+		return "", fmt.Errorf("Github auth session for %s has not been completed", userID)
 	}
 	return ghSession.AccessToken, nil
 }

--- a/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/github/github_webhook.go
@@ -156,7 +156,7 @@ func (s *WebhookService) Register(oldService types.Service, client *gomatrix.Cli
 	cli := s.githubClientFor(s.ClientUserID, false)
 	if cli == nil {
 		return fmt.Errorf(
-			"User %s does not have a Github auth session with realm %s.", s.ClientUserID, realm.ID())
+			"User %s does not have a Github auth session with realm %s", s.ClientUserID, realm.ID())
 	}
 
 	// Fetch the old service list and work out the difference between the two services.
@@ -182,7 +182,7 @@ func (s *WebhookService) Register(oldService types.Service, client *gomatrix.Cli
 		// The user didn't specify any webhooks. This may be a bug or it may be
 		// a conscious decision to remove all webhooks for this service. Figure out
 		// which it is by checking if we'd be removing any webhooks.
-		return fmt.Errorf("No webhooks specified.")
+		return fmt.Errorf("No webhooks specified")
 	}
 	for _, r := range newRepos {
 		logger := log.WithField("repo", r)

--- a/src/github.com/matrix-org/go-neb/services/jira/jira.go
+++ b/src/github.com/matrix-org/go-neb/services/jira/jira.go
@@ -101,7 +101,7 @@ func (s *Service) cmdJiraCreate(roomID, userID string, args []string) (interface
 	}
 
 	if !projectKeyRegex.MatchString(args[0]) {
-		return nil, errors.New("Project key must only contain A-Z.")
+		return nil, errors.New("Project key must only contain A-Z")
 	}
 
 	pkey := strings.ToUpper(args[0]) // REST API complains if they are not ALL CAPS
@@ -118,10 +118,10 @@ func (s *Service) cmdJiraCreate(roomID, userID string, args []string) (interface
 	r, err := s.projectToRealm(userID, pkey)
 	if err != nil {
 		log.WithError(err).Print("Failed to map project key to realm")
-		return nil, errors.New("Failed to map project key to a JIRA endpoint.")
+		return nil, errors.New("Failed to map project key to a JIRA endpoint")
 	}
 	if r == nil {
-		return nil, errors.New("No known project exists with that project key.")
+		return nil, errors.New("No known project exists with that project key")
 	}
 
 	iss := gojira.Issue{

--- a/src/github.com/matrix-org/go-neb/services/jira/webhook/webhook.go
+++ b/src/github.com/matrix-org/go-neb/services/jira/webhook/webhook.go
@@ -85,7 +85,7 @@ func RegisterHook(jrealm *jira.Realm, projects []string, userID, webhookEndpoint
 		// JIRA endpoint.
 		if !jrealm.HasWebhook {
 			logger.Print("No webhook exists for this realm.")
-			return fmt.Errorf("Not authorised to create webhook: not an admin.")
+			return fmt.Errorf("Not authorised to create webhook: not an admin")
 		}
 		return nil
 	}

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -81,7 +81,7 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 			numOldFeeds = len(oldFeedService.Feeds)
 		}
 		if numOldFeeds == 0 {
-			return errors.New("An RSS feed must be specified.")
+			return errors.New("An RSS feed must be specified")
 		}
 		return nil
 	}

--- a/src/github.com/matrix-org/go-neb/services/travisci/travisci.go
+++ b/src/github.com/matrix-org/go-neb/services/travisci/travisci.go
@@ -247,7 +247,7 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 		for repo := range roomData.Repos {
 			match := ownerRepoRegex.FindStringSubmatch(repo)
 			if len(match) == 0 {
-				return fmt.Errorf("Repository '%s' is not a valid repository name.", repo)
+				return fmt.Errorf("Repository '%s' is not a valid repository name", repo)
 			}
 		}
 	}
@@ -258,7 +258,7 @@ func (s *Service) Register(oldService types.Service, client *gomatrix.Client) er
 // PostRegister deletes this service if there are no registered repos.
 func (s *Service) PostRegister(oldService types.Service) {
 	for _, roomData := range s.Rooms {
-		for _ = range roomData.Repos {
+		for range roomData.Repos {
 			return // at least 1 repo exists
 		}
 	}


### PR DESCRIPTION
When the template fails to compile, it should log the error to the alertmanager console to provide some feedback on the details of the failure.