### PR TITLE
Improve formatting of RSS posts

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -356,9 +356,8 @@ func itemToHTML(feed *gofeed.Feed, item gofeed.Item) gomatrix.HTMLMessage {
 		Format: "org.matrix.custom.html",
 		FormattedBody: fmt.Sprintf("<strong>%s</strong>:<br><a href=\"%s\"><strong>%s</strong></a>",
 			html.EscapeString(feed.Title), html.EscapeString(item.Link), html.EscapeString(item.Title)),
-			// SomeOne posted a new article: Title Of The Entry ( https://someurl.com/blag )
 			// FeedTitle:
-			// Title of the Entry which is a Link to It
+			// Title of the Entry, as a Link to It
 	  }
 }
 

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -356,8 +356,9 @@ func itemToHTML(feed *gofeed.Feed, item gofeed.Item) gomatrix.HTMLMessage {
 		Format: "org.matrix.custom.html",
 		FormattedBody: fmt.Sprintf("<strong>%s</strong>:<br><a href=\"%s\"><strong>%s</strong></a>",
 			html.EscapeString(feed.Title), html.EscapeString(item.Link), html.EscapeString(item.Title)),
-			// FeedTitle:
-			// Title of the Entry, as a Link to It
+			// <strong>FeedTitle</strong>:
+			// <br>
+			// <a href="url-of-the-entry"><strong>Title of the Entry</strong></a>
 	  }
 }
 

--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -348,12 +348,18 @@ func (s *Service) sendToRooms(cli *gomatrix.Client, feedURL string, feed *gofeed
 	return nil
 }
 
-// SomeOne posted a new article: Title Of The Entry ( https://someurl.com/blag )
 func itemToHTML(feed *gofeed.Feed, item gofeed.Item) gomatrix.HTMLMessage {
-	return gomatrix.GetHTMLMessage("m.notice", fmt.Sprintf(
-		"<i>%s</i> posted a new article: %s ( %s )",
-		html.EscapeString(feed.Title), html.EscapeString(item.Title), html.EscapeString(item.Link),
-	))
+	return &gomatrix.HTMLMessage{
+		Body: fmt.Sprintf("%s: %s (%s)",
+			html.EscapeString(feed.Title), html.EscapeString(item.Title), html.EscapeString(item.Link)),
+		MsgType: "m.notice",
+		Format: "org.matrix.custom.html",
+		FormattedBody: fmt.Sprintf("<strong>%s</strong>:<br><a href=\"%s\"><strong>%s</strong></a>",
+			html.EscapeString(feed.Title), html.EscapeString(item.Link), html.EscapeString(item.Title)),
+			// SomeOne posted a new article: Title Of The Entry ( https://someurl.com/blag )
+			// FeedTitle:
+			// Title of the Entry which is a Link to It
+	  }
 }
 
 func ensureItemsHaveGUIDs(feed *gofeed.Feed) {


### PR DESCRIPTION
![Screenshot_2019-03-11 Riot  2](https://user-images.githubusercontent.com/13843293/54166271-7eec9c00-4432-11e9-8de5-bc40ebad65a9.png)
![Screenshot from 2019-03-11 19-06-47](https://user-images.githubusercontent.com/13843293/54166279-857b1380-4432-11e9-9551-e93af4144905.png)

Currently, if you have a room you use for several RSS feeds:

- It's difficult to quickly identify the RSS feed a given post came from, because the source is on the same line as all the other data, and it isn't clear where it ends, so you can't skim through them and identify what post came from what source by the length of the field.
- It's also not clear where the post title begins, for the same reason.
- Because the whole text of the link is included, in addition to the post title, it is liable to wrap to a 2nd line.
- Because of the " posted a new article", the already-long lines are made longer on both clients that support HTML-formatted Matrix messages and clients that don't. To convey that SomeRSSFeed is the source of a post, the context that the RSS bot is posting it, and a colon, as seen in the screenshots, should be enough.

I'm not familiar with Go, and I don't already have a test environment for running go-neb, so I didn't test this change. I'm hoping nothing is broken and that a quick review by a real Go developer and the CI will catch any problems I might've introduced.