### PR TITLE
Add support to GIPHY bot for downsampled images

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -67,7 +67,7 @@ services:
     UserID: "@goneb:localhost" # requires a Syncing client
     Config:
       api_key: "qwg4672vsuyfsfe"
-      use_downsized: false
+      image_type: 0
 
   - ID: "guggy_service"
     Type: "guggy"

--- a/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
+++ b/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
@@ -28,8 +28,10 @@ type image struct {
 type result struct {
 	Slug   string `json:"slug"`
 	Images struct {
-		Downsized image `json:"downsized"`
-		Original  image `json:"original"`
+		Original  		image `json:"original"`
+		DownsampledFixedHeight	image `json:"fixed_height_downsampled"`
+		DownsampledFixedWidth	image `json:"fixed_width_downsampled"`
+		Downsized 		image `json:"downsized"`
 	} `json:"images"`
 }
 
@@ -49,6 +51,14 @@ type Service struct {
 	// The Giphy API key to use when making HTTP requests to Giphy.
 	// The public beta API key is "dc6zaTOxFJmzC".
 	APIKey string `json:"api_key"`
+	
+	// Specifies whether to use downsampled/downsized image from Giphy.
+	// 0 indicates original image (defaults to this)
+	// 1 for downsized images
+	// 2 for fixed height downsampled, 3 for fixed width downsampled images
+	ImageType int `json:"image_type"`
+	
+	
 	// Whether to use the downsized image from Giphy.
 	// Uses the original image when set to false.
 	// Defaults to false.
@@ -78,9 +88,14 @@ func (s *Service) cmdGiphy(client *gomatrix.Client, roomID, userID string, args 
 	}
 
 	image := gifResult.Images.Original
-	if s.UseDownsized {
+	
+	switch s.ImageType {
+	case 1:
+		image = gifResult.Images.DownsampledFixedHeight
+	case 2:
+		image = gifResult.Images.DownsampledFixedWidth
+	case 3:
 		image = gifResult.Images.Downsized
-	}
 
 	if image.URL == "" {
 		return nil, fmt.Errorf("No results")

--- a/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
+++ b/src/github.com/matrix-org/go-neb/services/giphy/giphy.go
@@ -44,7 +44,7 @@ type giphySearch struct {
 // Example request:
 //   {
 //       "api_key": "dc6zaTOxFJmzC",
-//       "use_downsized": false
+//       "image_type": 0
 //   }
 type Service struct {
 	types.DefaultService
@@ -57,12 +57,6 @@ type Service struct {
 	// 1 for downsized images
 	// 2 for fixed height downsampled, 3 for fixed width downsampled images
 	ImageType int `json:"image_type"`
-	
-	
-	// Whether to use the downsized image from Giphy.
-	// Uses the original image when set to false.
-	// Defaults to false.
-	UseDownsized bool `json:"use_downsized"`
 }
 
 // Commands supported:
@@ -88,7 +82,6 @@ func (s *Service) cmdGiphy(client *gomatrix.Client, roomID, userID string, args 
 	}
 
 	image := gifResult.Images.Original
-	
 	switch s.ImageType {
 	case 1:
 		image = gifResult.Images.DownsampledFixedHeight


### PR DESCRIPTION
Addresses #217 , adding support for fixed_height_downsampled and fixed_width_downsampled images as per the GIPHY API to provide the option of reducing GIF file size further. Replaces use_downsized with image_type to support all four image types (original image, fixed height downsampled, fixed width downsampled, and downsized).

I'm relatively new to contributing to open source projects so if there is anything I could improve upon I am welcome to feedback, thank you!

---
Signed-off-by: William Pine <wpine215@gmail.com>