### PR TITLE
Fix mismatching types error

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -349,7 +349,7 @@ func (s *Service) sendToRooms(cli *gomatrix.Client, feedURL string, feed *gofeed
 }
 
 func itemToHTML(feed *gofeed.Feed, item gofeed.Item) gomatrix.HTMLMessage {
-	return &gomatrix.HTMLMessage{
+	return gomatrix.HTMLMessage{
 		Body: fmt.Sprintf("%s: %s (%s)",
 			html.EscapeString(feed.Title), html.EscapeString(item.Title), html.EscapeString(item.Link)),
 		MsgType: "m.notice",


### PR DESCRIPTION
A bug was introduced in https://github.com/matrix-org/go-neb/pull/269 and discovered by @bhush9.

The function body originally returned a `gomatrix.HTMLMessage` but was changed to return a `*gomatrix.HTMLMessage`. This has been fixed now and building works again.