### PR TITLE
Add spaces between URL and parenthesis

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -350,7 +350,7 @@ func (s *Service) sendToRooms(cli *gomatrix.Client, feedURL string, feed *gofeed
 
 func itemToHTML(feed *gofeed.Feed, item gofeed.Item) gomatrix.HTMLMessage {
 	return gomatrix.HTMLMessage{
-		Body: fmt.Sprintf("%s: %s (%s)",
+		Body: fmt.Sprintf("%s: %s ( %s )",
 			html.EscapeString(feed.Title), html.EscapeString(item.Title), html.EscapeString(item.Link)),
 		MsgType: "m.notice",
 		Format: "org.matrix.custom.html",


### PR DESCRIPTION
I'm getting complaints from users that the links created by RSS bot are not clickable as their client interprets the parenthesis as part of the URL. This change adds spaces between the URL and the parenthesis so that it looks sane and the URL's should be clickable on all clients.

Parenthesis can be part of URL in some cases, so it's understandable that clients consider them part of URL (although probably in wrong position).. Some discussion here: https://webmasters.stackexchange.com/questions/78110/is-it-bad-to-use-parentheses-in-a-url

I have not tested the change as it's trivial and I'm not running the bot myself.

Signed-off-by: Ville Ranki <ville.ranki@iki.fi>