### PR TITLE
Add an example Alertmanager config

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -136,3 +136,19 @@ services:
         "hook1":
           RoomID: "!someroom:id"
           MessageType: "m.text" # default is m.text
+
+  - ID: "alertmanager_service"
+    Type: "alertmanager"
+    UserID: "@alertmanager:localhost"
+    Config:
+      # This is for information purposes only. It should point to Go-NEB path as follows:
+      # `/services/hooks/<base64 encoded service ID>`
+      # Where in this case "service ID" is "alertmanager_service"
+      # Make sure your BASE_URL can be accessed by the Alertmanager instance!
+      webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2UK"
+      # Each room will get the notification with the alert rendered with the given template
+      rooms:
+        "!someroomid:domain.tld":
+          text_template: "{{range .Alerts -}} [{{ .Status }}] {{index .Labels \"alertname\" }}: {{index .Annotations \"description\"}} {{ end -}}"
+          html_template: "{{range .Alerts -}}  {{ $severity := index .Labels \"severity\" }}    {{ if eq .Status \"firing\" }}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorUrl }}\">source</a><br/>{{end -}}"
+          msg_type: "m.text"  # Must be either `m.text` or `m.notice`


### PR DESCRIPTION
For when running in config file mode. The same example can be used
to manually insert into the SQLite database or figure out
how to use the services API to configure Alertmanager service

Refs: #264
Signed-off-by: Jason Robinson <jasonr@matrix.org>