### PR TITLE
Correct alertmanager webhook_url and GeneratorURL examples

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -155,10 +155,10 @@ services:
       # `/services/hooks/<base64 encoded service ID>`
       # Where in this case "service ID" is "alertmanager_service"
       # Make sure your BASE_URL can be accessed by the Alertmanager instance!
-      webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2UK"
+      webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2U"
       # Each room will get the notification with the alert rendered with the given template
       rooms:
         "!someroomid:domain.tld":
           text_template: "{{range .Alerts -}} [{{ .Status }}] {{index .Labels \"alertname\" }}: {{index .Annotations \"description\"}} {{ end -}}"
-          html_template: "{{range .Alerts -}}  {{ $severity := index .Labels \"severity\" }}    {{ if eq .Status \"firing\" }}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorUrl }}\">source</a><br/>{{end -}}"
+          html_template: "{{range .Alerts -}}  {{ $severity := index .Labels \"severity\" }}    {{ if eq .Status \"firing\" }}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorURL }}\">source</a><br/>{{end -}}"
           msg_type: "m.text"  # Must be either `m.text` or `m.notice`


### PR DESCRIPTION
A couple small issues in the `config.sample.yml` file for the alertmanager service were giving me trouble, wanted to update the sample file so that people don't run into the same issues.

The base64 encoding of `alertmanager_service` is actually `YWxlcnRtYW5hZ2VyX3NlcnZpY2U`, not `YWxlcnRtYW5hZ2VyX3NlcnZpY2UK`. The latter example (the one currently in the sample file) gets decoded as `alertmanager_service\n`. A small difference that was hard to spot in my logs.

Also, the `.GeneratorUrl` value referenced in the template should be `.GeneratorURL`, per the [alertmanager documentation](https://prometheus.io/docs/alerting/configuration/#webhook_config).

Signed-off-by: Devin Dooley <devinadooley@gmail.com>