### PR TITLE
Add simple Mumble client to notify a room on join/leave

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/matrix-org/go-neb
 go 1.14
 
 require (
-	github.com/PuerkitoBio/goquery v1.5.1 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
 	github.com/andygrunwald/go-jira v1.11.0
@@ -51,5 +50,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0
+	layeh.com/gumble v0.0.0-20200818122324-146f9205029b
 	maunium.net/go/mautrix v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchote/go-openal v0.0.0-20171116030048-f4a9a141d372/go.mod h1:74z+CYu2/mx4N+mcIS/rsvfAxBPBV9uv8zRAnwyFkdI=
 github.com/dghubble/oauth1 v0.6.0 h1:m1yC01Ohc/eF38jwZ8JUjL1a+XHHXtGQgK+MxQbmSx0=
 github.com/dghubble/oauth1 v0.6.0/go.mod h1:8pFdfPkv/jr8mkChVbNVuJ0suiHe278BtWI4Tk1ujxk=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -262,6 +263,9 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+layeh.com/gopus v0.0.0-20161224163843-0ebf989153aa/go.mod h1:AOef7vHz0+v4sWwJnr0jSyHiX/1NgsMoaxl+rEPz/I0=
+layeh.com/gumble v0.0.0-20200818122324-146f9205029b h1:Kne6wkHqbqrygRsqs5XUNhSs84DFG5TYMeCkCbM56sY=
+layeh.com/gumble v0.0.0-20200818122324-146f9205029b/go.mod h1:tWPVA9ZAfImNwabjcd9uDE+Mtz0Hfs7a7G3vxrnrwyc=
 maunium.net/go/maulogger/v2 v2.1.1/go.mod h1:TYWy7wKwz/tIXTpsx8G3mZseIRiC5DoMxSZazOHy68A=
 maunium.net/go/mautrix v0.4.2/go.mod h1:8Y+NqmROJyWYvvP4yPfX9tLM59VCfgE/kcQ0SeX68ho=
 maunium.net/go/mautrix v0.4.7 h1:jpclbeGcuiHPIWZFZhQJoxgZKP9f+9OLBPtcDNMFV/o=

--- a/goneb.go
+++ b/goneb.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/matrix-org/go-neb/services/imgur"
 
 	_ "github.com/matrix-org/go-neb/services/jira"
+	_ "github.com/matrix-org/go-neb/services/mumble"
 	_ "github.com/matrix-org/go-neb/services/rssbot"
 	_ "github.com/matrix-org/go-neb/services/slackapi"
 	_ "github.com/matrix-org/go-neb/services/travisci"

--- a/services/mumble/mumble.go
+++ b/services/mumble/mumble.go
@@ -1,0 +1,71 @@
+package mumble
+
+import (
+	"crypto/tls"
+	"fmt"
+	"layeh.com/gumble/gumble"
+	"layeh.com/gumble/gumbleutil"
+	"net"
+
+	"github.com/matrix-org/go-neb/types"
+	mevt "maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+// ServiceType of the Mumble service
+const ServiceType = "mumble"
+
+type Service struct {
+	types.DefaultService
+	Endpoint string `json:"endpoint"`
+	Insecure bool   `json:"insecure"`
+	Username string `json:"username"`
+	Room     string `json:"room"`
+}
+
+func (s *Service) Register(oldService types.Service, client types.MatrixClient) error {
+
+	config := gumble.NewConfig()
+	config.Username = s.Username
+
+	config.Attach(gumbleutil.Listener{
+		UserChange: func(e *gumble.UserChangeEvent) {
+			if e.Type.Has(gumble.UserChangeConnected) {
+				msg := mevt.MessageEventContent{
+					Body:    fmt.Sprintf("User %s has joined Mumble!", e.User.Name),
+					MsgType: "m.notice",
+				}
+				client.SendMessageEvent(id.RoomID(s.Room), mevt.EventMessage, msg)
+			} else if e.Type.Has(gumble.UserChangeDisconnected) {
+				msg := mevt.MessageEventContent{
+					Body:    fmt.Sprintf("User %s has left Mumble", e.User.Name),
+					MsgType: "m.notice",
+				}
+				client.SendMessageEvent(id.RoomID(s.Room), mevt.EventMessage, msg)
+			}
+		},
+	})
+	var tlsConfig tls.Config
+	if s.Insecure {
+		tlsConfig = tls.Config{
+			InsecureSkipVerify: true,
+		}
+	} else {
+		tlsConfig = tls.Config{}
+	}
+
+	_, err := gumble.DialWithDialer(new(net.Dialer), s.Endpoint, config, &tlsConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	types.RegisterService(func(serviceID string, serviceUserID id.UserID, webhookEndpointURL string) types.Service {
+		return &Service{
+			DefaultService: types.NewDefaultService(serviceID, serviceUserID, ServiceType),
+		}
+	})
+}


### PR DESCRIPTION
This adds a Mumble service that sits on a Mumble server and notifies a
Matrix room of users that join and leave. I'd like to expand this
functionality shortly (possibly including templates as found in the
Alertmanager service, or multiple Matrix rooms) but this has basic
functionality now.

I was sort of guessing at some of the API based on some of the
existing services, and I'm extremely new to Go. (This is the first Go
project I've contributed to!) Feedback on what I've inevitably done
horribly wrong is welcome. :)