### PR TITLE
CI: Ensure we run on go.mod|sum changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,15 @@ on:
   pull_request:
     paths:
       - '**.go'
+      - 'go.mod'
+      - 'go.sum'
     branches:
       - master
   push:
     paths:
       - '**.go'
+      - 'go.mod'
+      - 'go.sum'
     branches:
       - master
     tags-ignore:


### PR DESCRIPTION
I noticed that after the rebase for #351 CI didn't run, whereas it should (since we're upgrading packages). This happens because as part of #350 we forgot to include go.mod|sum files as triggers.