### PR TITLE
Add MinimumPowerLevel option to clients

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -82,6 +82,8 @@ type ClientConfig struct {
 	// When a user starts a new SAS verification with us, their user ID has to match one of these regexes
 	// for the verification process to start.
 	AcceptVerificationFromUsers []string
+	// The minimum required powerlevel to honour an invite request
+	MinimumPowerLevel int
 }
 
 // A IncomingDecimalSAS contains the decimal SAS as displayed on another device. The SAS consists of three numbers.

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -303,7 +303,7 @@ func (c *Clients) onBotOptionsEvent(client *mautrix.Client, event *mevt.Event) {
 	}
 }
 
-func (c *Clients) onRoomMemberEvent(client *mautrix.Client, event *mevt.Event) {
+func (c *Clients) onRoomMemberEvent(client *BotClient, event *mevt.Event) {
 	if event.StateKey == nil || *event.StateKey != client.UserID.String() {
 		return // not our member event
 	}
@@ -316,14 +316,35 @@ func (c *Clients) onRoomMemberEvent(client *mautrix.Client, event *mevt.Event) {
 		})
 		logger.Print("Accepting invite from user")
 
-		content := struct {
+		inviteContent := struct {
 			Inviter id.UserID `json:"inviter"`
 		}{event.Sender}
 
-		if _, err := client.JoinRoom(event.RoomID.String(), "", content); err != nil {
+		if _, err := client.JoinRoom(event.RoomID.String(), "", inviteContent); err != nil {
 			logger.WithError(err).Print("Failed to join room")
-		} else {
-			logger.Print("Joined room")
+			return
+		}
+		logger.Print("Joined room")
+		var rID = id.RoomID(event.RoomID.String())
+		var plContent struct {
+			Users        map[string]int `json:"users"`
+			UsersDefault int
+		}
+		if client.config.MinimumPowerLevel == 0 {
+			return
+		}
+		if err := client.StateEvent(rID, mevt.StatePowerLevels, "", &plContent); err != nil {
+			logger.WithError(err).Print("Failed to get powerlevels from room")
+			client.LeaveRoom(rID)
+			return
+		}
+		var pl = plContent.Users[event.Sender.String()]
+		if pl == 0 {
+			pl = plContent.UsersDefault
+		}
+		if pl < client.config.MinimumPowerLevel {
+			logger.Warningln("User tried to invite the bot without the required PLs, ignoring")
+			client.LeaveRoom(rID)
 		}
 	}
 }
@@ -372,7 +393,7 @@ func (c *Clients) initClient(botClient *BotClient) error {
 
 	if config.AutoJoinRooms {
 		syncer.OnEventType(mevt.StateMember, func(_ mautrix.EventSource, event *mevt.Event) {
-			c.onRoomMemberEvent(client, event)
+			c.onRoomMemberEvent(botClient, event)
 		})
 	}
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -27,6 +27,7 @@ clients:
     AutoJoinRooms: true
     DisplayName: "Go-NEB!"
     AcceptVerificationFromUsers: [":localhost:8008"]
+    MinimumPowerLevel: 50
 
   - UserID: "@another_goneb:localhost"
     AccessToken: "MDASDASJDIASDJASDAFGFRGER"
@@ -36,6 +37,7 @@ clients:
     AutoJoinRooms: false
     DisplayName: "Go-NEB!"
     AcceptVerificationFromUsers: ["^@admin:localhost:8008$"]
+    MinimumPowerLevel: 100
 
 # The list of realms which Go-NEB is aware of.
 # Delete or modify this list as appropriate.


### PR DESCRIPTION
This change adds an option to specify the minimum PL level of the inviting user for the bot to remain joined to the room. This change will only affect services which accept invites to rooms, so services like GitHub need a different change.