### PR TITLE
Add support for GitHub labels when creating a new issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.16.4'
+        go-version: '~1.18.0'
     - name: Install libolm
       run: sudo apt-get -y install libolm3 libolm-dev
     - name: Install linters

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -330,9 +330,9 @@ func (c *Clients) onRoomMemberEvent(client *mautrix.Client, event *mevt.Event) {
 
 type BotOptionsContent struct {
 	Github struct {
-		DefaultRepo    string `json:"default_repo,omitempty"`
-		NewIssueLabels string `json:"new_issue_labels,omitempty"`
-	}
+		DefaultRepo    string   `json:"default_repo,omitempty"`
+		NewIssueLabels []string `json:"new_issue_labels,omitempty"`
+	} `json:"github"`
 }
 
 func (c *Clients) initClient(botClient *BotClient) error {

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -16,7 +16,6 @@ import (
 	shellwords "github.com/mattn/go-shellwords"
 	log "github.com/sirupsen/logrus"
 	"maunium.net/go/mautrix"
-	"maunium.net/go/mautrix/event"
 	mevt "maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 )
@@ -345,14 +344,11 @@ func (c *Clients) initClient(botClient *BotClient) error {
 	botClient.verificationSAS = &sync.Map{}
 
 	syncer := client.Syncer.(*mautrix.DefaultSyncer)
-	syncer.ParseErrorHandler = func(evt *event.Event, err error) bool {
+	syncer.ParseErrorHandler = func(evt *mevt.Event, err error) bool {
 		// Events of type m.room.bot.options will be flagged as errors as this isn't an event type
 		// recognised by the Syncer, but we need to process them so the bot can accept options
 		// through this event (see onBotOptionsEvent)
-		if evt.Type.Type == "m.room.bot.options" {
-			return true
-		}
-		return false
+		return evt.Type.Type == "m.room.bot.options"
 	}
 
 	nebStore := &matrix.NEBStore{

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -16,6 +16,7 @@ import (
 	shellwords "github.com/mattn/go-shellwords"
 	log "github.com/sirupsen/logrus"
 	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
 	mevt "maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 )
@@ -344,6 +345,15 @@ func (c *Clients) initClient(botClient *BotClient) error {
 	botClient.verificationSAS = &sync.Map{}
 
 	syncer := client.Syncer.(*mautrix.DefaultSyncer)
+	syncer.ParseErrorHandler = func(evt *event.Event, err error) bool {
+		// Events of type m.room.bot.options will be flagged as errors as this isn't an event type
+		// recognised by the Syncer, but we need to process them so the bot can accept options
+		// through this event (see onBotOptionsEvent)
+		if evt.Type.Type == "m.room.bot.options" {
+			return true
+		}
+		return false
+	}
 
 	nebStore := &matrix.NEBStore{
 		InMemoryStore: *mautrix.NewInMemoryStore(),
@@ -366,7 +376,7 @@ func (c *Clients) initClient(botClient *BotClient) error {
 		c.onMessageEvent(botClient, event)
 	})
 
-	syncer.OnEventType(mevt.Type{Type: "m.room.bot.options", Class: mevt.UnknownEventType}, func(_ mautrix.EventSource, event *mevt.Event) {
+	syncer.OnEventType(mevt.Type{Type: "m.room.bot.options", Class: mevt.StateEventType}, func(_ mautrix.EventSource, event *mevt.Event) {
 		c.onBotOptionsEvent(botClient.Client, event)
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	maunium.net/go/mautrix v0.9.12

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f h1:8w7RhxzTVgUzw/AH/9mUV5q0vMgy40SQRursCcfmkCw=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/services/github/github.go
+++ b/services/github/github.go
@@ -60,8 +60,8 @@ var ownerRepoRegex = regexp.MustCompile(`^([A-z0-9-_.]+)/([A-z0-9-_.]+)$`)
 //      // when creating/expanding issues.
 //      "default_repo": "owner/repo",
 //
-//      // Comma-separated Github labels to attach to any issue created by this bot in this room.
-//      "new_issue_labels": "bot-label-1, bot-label-2"
+//      // Array of Github labels to attach to any issue created by this bot in this room.
+//      "new_issue_labels": ["bot-label-1", "bot-label-2"]
 //    }
 //  }
 //
@@ -794,11 +794,15 @@ func (s *Service) newIssueLabels(roomID id.RoomID) []string {
 	if err != nil {
 		return make([]string, 0)
 	}
-	newIssueLabels, ok := ghOpts["new_issue_labels"].(string)
+	newIssueLabels, ok := ghOpts["new_issue_labels"].([]interface{})
 	if !ok {
 		return make([]string, 0)
 	}
-	return strings.Split(newIssueLabels, ",")
+	newIssueLabelsUnboxed := make([]string, 0)
+	for _, s := range newIssueLabels {
+		newIssueLabelsUnboxed = append(newIssueLabelsUnboxed, s.(string))
+	}
+	return newIssueLabelsUnboxed
 }
 
 func (s *Service) githubClientFor(userID id.UserID, allowUnauth bool) *gogithub.Client {

--- a/services/github/github.go
+++ b/services/github/github.go
@@ -755,7 +755,12 @@ func (s *Service) loadBotOptions(roomID id.RoomID, logger *log.Entry) (result ma
 		}
 	}
 	// Expect opts to look like:
-	// { github: { default_repo: $OWNER_REPO } }
+	// {
+	//   github: {
+	//      default_repo: $OWNER_REPO,
+	//      new_issue_labels: [ "label1", .. ]
+	//   }
+	// }
 	ghOpts, ok := opts.Options["github"].(map[string]interface{})
 	if !ok {
 		err = fmt.Errorf("Failed to cast bot options as github options")

--- a/services/github/github.go
+++ b/services/github/github.go
@@ -76,6 +76,11 @@ type Service struct {
 	RealmID string
 }
 
+type Options struct {
+	DefaultRepo    string   `json:"default_repo,omitempty"`
+	NewIssueLabels []string `json:"new_issue_labels,omitempty"`
+}
+
 func (s *Service) requireGithubClientFor(userID id.UserID) (cli *gogithub.Client, resp interface{}, err error) {
 	cli = s.githubClientFor(userID, false)
 	if cli == nil {

--- a/types/service.go
+++ b/types/service.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"github.com/matrix-org/go-neb/services/github"
 	"net/http"
 	"strings"
 	"time"
@@ -14,8 +13,13 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
+type GithubOptions struct {
+	DefaultRepo    string   `json:"default_repo,omitempty"`
+	NewIssueLabels []string `json:"new_issue_labels,omitempty"`
+}
+
 type BotOptionsContent struct {
-	Github github.Options `json:"github"`
+	Github GithubOptions `json:"github"`
 }
 
 // BotOptions for a given bot user in a given room
@@ -23,7 +27,7 @@ type BotOptions struct {
 	RoomID      id.RoomID
 	UserID      id.UserID
 	SetByUserID id.UserID
-	Options     BotOptionsContent
+	Options     *BotOptionsContent
 }
 
 // Poller represents a thing which can poll. Services should implement this method signature to support polling.

--- a/types/service.go
+++ b/types/service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"github.com/matrix-org/go-neb/services/github"
 	"net/http"
 	"strings"
 	"time"
@@ -13,12 +14,16 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
+type BotOptionsContent struct {
+	Github github.Options `json:"github"`
+}
+
 // BotOptions for a given bot user in a given room
 type BotOptions struct {
 	RoomID      id.RoomID
 	UserID      id.UserID
 	SetByUserID id.UserID
-	Options     map[string]interface{}
+	Options     BotOptionsContent
 }
 
 // Poller represents a thing which can poll. Services should implement this method signature to support polling.


### PR DESCRIPTION
Augmented the current `m.room.bot.options` format for the github integration to support new_issue_labels, a comma separated list of label names that will be added to the issue.

This is useful for triggering subsequent automation from bot-created issues.

This partly addresses https://github.com/matrix-org/go-neb/issues/349 - although that issue notes that not everyone will have permission to add labels. I didn't attempt to address that here; this feature will just be less useful for those particular cases.