### PR TITLE
Dockerfile: add HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ ENV BIND_ADDRESS=:4050 \
     DATABASE_URL=/data/go-neb.db?_busy_timeout=5000 \
     UID=1337 \
     GID=1337
+    
+HEALTHCHECK --interval=5s --timeout=3s CMD wget -qS -O /dev/null localhost${BIND_ADDRESS}/test | awk -F':' '$1 ~ / Status$/ { print $2 ~ /200 OK/ }'
 
 COPY --from=builder /tmp/go-neb/go-neb /usr/local/bin/go-neb
 # Copy libolm.so


### PR DESCRIPTION
Add `wge`t based healthchecks. Don't want to add `curl` just for healthchecks and increase size of image by ~2.5 MB(Every penny counts) when you can achieve similar with alpine's built-in `wget` and `awk`.